### PR TITLE
Trio101: Never yield inside a nursery or cancel scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ pip install git+https://github.com/Zac-HD/flake8-trio
 - **TRIO100**: a `with trio.fail_after(...):` or `with trio.move_on_after(...):`
   context does not contain any `await` statements.  This makes it pointless, as
   the timeout can only be triggered by a checkpoint.
+- **TRIO101** `yield` inside a nursery or cancel scope is only safe when implementing a context manager - otherwise, it breaks exception handling.

--- a/flake8_trio.py
+++ b/flake8_trio.py
@@ -120,4 +120,4 @@ class Plugin:
 
 
 TRIO100 = "TRIO100: {} context contains no checkpoints, add `await trio.sleep(0)`"
-TRIO101 = "TRIO101: {} never yield inside a nursery or cancel scope"
+TRIO101 = "TRIO101: yield inside a {} context is only safe when implementing a context manager - otherwise, it breaks exception handling"

--- a/tests/test_flake8_trio.py
+++ b/tests/test_flake8_trio.py
@@ -41,10 +41,12 @@ class Flake8TrioTestCase(unittest.TestCase):
         )
 
     def test_trio101(self):
+        self.maxDiff = None
         self.assert_expected_errors(
             "trio101.py",
-            make_error(TRIO101, 7, 9, "trio.open_nursery"),
-            make_error(TRIO101, 12, 15, "trio.open_nursery"),
+            make_error(TRIO101, 8, 8),
+            make_error(TRIO101, 13, 8),
+            make_error(TRIO101, 25, 8),
         )
 
 

--- a/tests/test_flake8_trio.py
+++ b/tests/test_flake8_trio.py
@@ -9,7 +9,7 @@ import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesmith import from_grammar, from_node
 
-from flake8_trio import TRIO100, Error, Plugin, Visitor, make_error
+from flake8_trio import TRIO100, TRIO101, Error, Plugin, Visitor, make_error
 
 
 class Flake8TrioTestCase(unittest.TestCase):
@@ -38,6 +38,13 @@ class Flake8TrioTestCase(unittest.TestCase):
             make_error(TRIO100, 7, 8, "trio.fail_after"),
             make_error(TRIO100, 12, 8, "trio.fail_after"),
             make_error(TRIO100, 14, 8, "trio.move_on_after"),
+        )
+
+    def test_trio101(self):
+        self.assert_expected_errors(
+            "trio101.py",
+            make_error(TRIO101, 7, 9, "trio.open_nursery"),
+            make_error(TRIO101, 12, 15, "trio.open_nursery"),
         )
 
 

--- a/tests/test_flake8_trio.py
+++ b/tests/test_flake8_trio.py
@@ -44,15 +44,16 @@ class Flake8TrioTestCase(unittest.TestCase):
         self.maxDiff = None
         self.assert_expected_errors(
             "trio101.py",
-            make_error(TRIO101, 8, 8),
-            make_error(TRIO101, 13, 8),
-            make_error(TRIO101, 25, 8),
+            make_error(TRIO101, 10, 8),
+            make_error(TRIO101, 15, 8),
+            make_error(TRIO101, 27, 8),
+            make_error(TRIO101, 38, 8),
         )
 
 
 @pytest.mark.fuzz
 class TestFuzz(unittest.TestCase):
-    @settings(max_examples=10_000, suppress_health_check=[HealthCheck.too_slow])
+    @settings(max_examples=1_000, suppress_health_check=[HealthCheck.too_slow])
     @given((from_grammar() | from_node()).map(ast.parse))
     def test_does_not_crash_on_any_valid_code(self, syntax_tree: ast.AST):
         # Given any syntatically-valid source code, the checker should

--- a/tests/trio101.py
+++ b/tests/trio101.py
@@ -1,3 +1,5 @@
+import contextlib
+import contextlib as bla
 from contextlib import asynccontextmanager, contextmanager
 
 import trio
@@ -28,4 +30,24 @@ async def foo3():
 @asynccontextmanager
 async def foo4():
     async with trio.open_nursery() as _:
+        yield 1  # safe
+
+
+async def foo5():
+    async with trio.open_nursery():
+        yield 1  # error
+
+        def foo6():
+            yield 1  # safe
+
+
+@contextlib.asynccontextmanager
+async def foo7():
+    async with trio.open_nursery() as _:
+        yield 1  # safe
+
+
+@bla.contextmanager
+def foo8():
+    with trio.open_nursery() as _:
         yield 1  # safe

--- a/tests/trio101.py
+++ b/tests/trio101.py
@@ -5,21 +5,27 @@ import trio
 
 def foo0():
     with trio.open_nursery() as _:
-        yield 1
+        yield 1  # error
 
 
 async def foo1():
     async with trio.open_nursery() as _:
-        yield 1
+        yield 1  # error
 
 
 @contextmanager
 def foo2():
     with trio.open_nursery() as _:
-        yield 1
+        yield 1  # safe
+
+
+async def foo3():
+    async with trio.CancelScope() as _:
+        await trio.sleep(1)  # so trio100 doesn't complain
+        yield 1  # error
 
 
 @asynccontextmanager
-async def foo3():
+async def foo4():
     async with trio.open_nursery() as _:
-        yield 1
+        yield 1  # safe

--- a/tests/trio101.py
+++ b/tests/trio101.py
@@ -1,0 +1,25 @@
+from contextlib import asynccontextmanager, contextmanager
+
+import trio
+
+
+def foo0():
+    with trio.open_nursery() as _:
+        yield 1
+
+
+async def foo1():
+    async with trio.open_nursery() as _:
+        yield 1
+
+
+@contextmanager
+def foo2():
+    with trio.open_nursery() as _:
+        yield 1
+
+
+@asynccontextmanager
+async def foo3():
+    async with trio.open_nursery() as _:
+        yield 1

--- a/tox.ini
+++ b/tox.ini
@@ -28,11 +28,11 @@ description = Runs pytest, optionally with posargs
 deps =
     pytest
     pytest-cov
-    pytest-xdist
+    #pytest-xdist
     hypothesis
     hypothesmith
 commands =
-    pytest {posargs:-n auto}
+    pytest #{posargs:-n auto}
 
 
 # Settings for other tools


### PR DESCRIPTION
Not entirely sure dumping a bunch of yields into a set is the best way to avoid false positives, but other than doing the reverse (saving `contextmanagers`/`functiondefs`, or their linenos) I couldn't figure out a neater way of doing it.

Didn't bother trying to juggle out trio100 changes, so you might want to merge the first pull request before looking at this diff.