### PR TITLE
Trio102: await inside finally needs shielding and timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 *[CalVer, YY.month.patch](https://calver.org/)*
 
 ## 22.7.3
-Added:
-- **TRIO102** `await` in `finally` must have a cancel scope with shielding.
+- Added TRIO102 check for unsafe checkpoints inside `finally:` blocks
 
 ## 22.7.2
 - Avoid `TRIO100` false-alarms on cancel scopes containing `async for` or `async with`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 *[CalVer, YY.month.patch](https://calver.org/)*
 
+## 22.7.2
+Added:
+- **TRIO102** `await` in `finally` must have a cancel scope with shielding.
+
 ## 22.7.1
 
-- Initial release
+- Initial release with TRIO100 and TRIO101

--- a/README.md
+++ b/README.md
@@ -22,4 +22,5 @@ pip install flake8-trio
   context does not contain any `await` statements.  This makes it pointless, as
   the timeout can only be triggered by a checkpoint.
 - **TRIO101** `yield` inside a nursery or cancel scope is only safe when implementing a context manager - otherwise, it breaks exception handling.
-- **TRIO102** `await` in `finally` must have a cancel scope with shielding.
+- **TRIO102** it's unsafe to await inside `finally:` unless you use a shielded
+  cancel scope with a timeout"

--- a/README.md
+++ b/README.md
@@ -28,3 +28,4 @@ pip install git+https://github.com/Zac-HD/flake8-trio
   context does not contain any `await` statements.  This makes it pointless, as
   the timeout can only be triggered by a checkpoint.
 - **TRIO101** `yield` inside a nursery or cancel scope is only safe when implementing a context manager - otherwise, it breaks exception handling.
+- **TRIO102** `await` in `finally` must have a cancel scope with shielding.

--- a/flake8_trio.py
+++ b/flake8_trio.py
@@ -184,7 +184,7 @@ class Visitor(ast.NodeVisitor):
         # There's no visit_Finally, so we need to manually visit the Try fields.
         # It's important to do self.visit instead of self.generic_visit since
         # the nodes in the fields might be registered elsewhere in this class.
-        for item in *node.body, *node.handlers, *node.orelse:
+        for item in (*node.body, *node.handlers, *node.orelse):
             self.visit(item)
 
         outer = self._inside_finally

--- a/flake8_trio.py
+++ b/flake8_trio.py
@@ -14,7 +14,7 @@ import tokenize
 from typing import Any, Generator, List, Optional, Set, Tuple, Type, Union
 
 # CalVer: YY.month.patch, e.g. first release of July 2022 == "22.7.1"
-__version__ = "22.7.1"
+__version__ = "22.7.2"
 
 
 Error = Tuple[int, int, str, Type[Any]]
@@ -146,7 +146,6 @@ class Visitor(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_With(self, node: ast.With) -> None:
-        # print('poop')
         self.visit_generic_with(node)
 
     def visit_AsyncWith(self, node: ast.AsyncWith) -> None:

--- a/flake8_trio.py
+++ b/flake8_trio.py
@@ -11,7 +11,7 @@ Pairs well with flake8-async and flake8-bugbear.
 
 import ast
 import tokenize
-from typing import Any, Generator, List, Optional, Set, Tuple, Type, Union
+from typing import Any, Generator, List, Optional, Tuple, Type, Union
 
 # CalVer: YY.month.patch, e.g. first release of July 2022 == "22.7.1"
 __version__ = "22.7.3"
@@ -76,90 +76,145 @@ def get_trio_scope(node: ast.AST, *names: str) -> Optional[TrioScope]:
     return None
 
 
+class Visitor102(ast.NodeVisitor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.problems: List[Error] = []
+        self._inside_finally: Optional[ast.Try] = None
+        self._scopes: List[TrioScope] = []
+        self._context_manager = False
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        # checks for <scopename>.shield = [True/False]
+        if self._scopes:
+            last_scope = self._scopes[-1]
+            if (
+                last_scope.variable_name is not None
+                and len(node.targets) == 1
+                and isinstance(node.targets[0], ast.Attribute)
+                and isinstance(node.targets[0].value, ast.Name)
+                and node.targets[0].value.id == last_scope.variable_name
+                and node.targets[0].attr == "shield"
+                and isinstance(node.value, ast.Constant)
+            ):
+                last_scope.shielded = node.value.value
+        self.generic_visit(node)
+
+    def check_for_trio102(self, node: Union[ast.Await, ast.AsyncFor, ast.AsyncWith]):
+        # if we're inside a finally, and not inside a context_manager, and we're not
+        # inside a scope that doesn't have both a timeout and shield
+        if self._inside_finally is not None and not self._context_manager:
+            for scope in self._scopes:
+                if scope.timeout and scope.shielded:
+                    break
+            else:
+                self.problems.append(make_error(TRIO102, node.lineno, node.col_offset))
+
+    def visit_Await(self, node: ast.Await) -> None:
+        self.check_for_trio102(node)
+        self.generic_visit(node)
+
+    def visit_With(self, node: Union[ast.With, ast.AsyncWith]) -> None:
+        trio_scope = None
+
+        # Check for a `with trio.<scope_creater>`
+        for item in node.items:
+            trio_scope = get_trio_scope(
+                item.context_expr, "open_nursery", *cancel_scope_names
+            )
+            if trio_scope is not None:
+                # check if it's saved in a variable
+                if isinstance(item.optional_vars, ast.Name):
+                    trio_scope.variable_name = item.optional_vars.id
+                break
+
+        if trio_scope is not None:
+            self._scopes.append(trio_scope)
+
+        self.generic_visit(node)
+
+        if trio_scope is not None:
+            self._scopes.pop()
+
+    def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
+        self.check_for_trio102(node)
+        self.visit_With(node)
+
+    def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
+        self.check_for_trio102(node)
+        self.generic_visit(node)
+
+    def visit_FunctionDef(
+        self, node: Union[ast.FunctionDef, ast.AsyncFunctionDef]
+    ) -> None:
+        outer_cm = self._context_manager
+
+        # check for @<context_manager_name> and @<library>.<context_manager_name>
+        if any(
+            (isinstance(d, ast.Name) and d.id in context_manager_names)
+            or (isinstance(d, ast.Attribute) and d.attr in context_manager_names)
+            for d in node.decorator_list
+        ):
+            self._context_manager = True
+        self.generic_visit(node)
+        self._context_manager = outer_cm
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self.visit_FunctionDef(node)
+
+    def visit_Try(self, node: ast.Try) -> None:
+        # There's no visit_Finally, so we need to manually visit the Try fields.
+        # It's important to do self.visit instead of self.generic_visit since
+        # the nodes in the fields might be registered elsewhere in this class.
+        for item in (*node.body, *node.handlers, *node.orelse):
+            self.visit(item)
+
+        outer = self._inside_finally
+        outer_scopes = self._scopes
+
+        self._scopes = []
+        self._inside_finally = node
+
+        for item in node.finalbody:
+            self.visit(item)
+
+        self._scopes = outer_scopes
+        self._inside_finally = outer
+
+
 class Visitor(ast.NodeVisitor):
     def __init__(self) -> None:
         super().__init__()
         self.problems: List[Error] = []
-        self.safe_yields: Set[ast.Yield] = set()
         self._yield_is_error = False
         self._context_manager = False
-        self._inside_finally: Optional[ast.Try] = None
-        self._scope: Optional[TrioScope] = None
 
-    def visit_generic_with(self, node: Union[ast.With, ast.AsyncWith]):
+    def visit_With(self, node: Union[ast.With, ast.AsyncWith]) -> None:
         self.check_for_trio100(node)
 
         outer_yie = self._yield_is_error
-        outer_scope = self._scope
 
         # Check for a `with trio.<scope_creater>`
-        trio_scope = next(
-            (
-                get_trio_scope(item, "open_nursery", *cancel_scope_names)
-                for item in (i.context_expr for i in node.items)
-            ),
-            None,
-        )
-        if trio_scope is not None:
-            if not self._context_manager:
-                self._yield_is_error = True
+        if not self._context_manager:
+            for item in (i.context_expr for i in node.items):
+                if (
+                    get_trio_scope(item, "open_nursery", *cancel_scope_names)
+                    is not None
+                ):
+                    self._yield_is_error = True
+                    break
 
-            # Check for `with [...] as <varname>`
-            trio_scope.variable_name = next(
-                (
-                    item.optional_vars.id
-                    for item in node.items
-                    if isinstance(item.optional_vars, ast.Name)
-                ),
-                None,
-            )
-            self._scope = trio_scope
         self.generic_visit(node)
 
-        # reset scope and yield_is_error
+        # reset yield_is_error
         self._yield_is_error = outer_yie
-        self._scope = outer_scope
-
-    def visit_Assign(self, node: ast.Assign) -> None:
-        # checks for <scopename>.shield = [True/False]
-        if (
-            self._scope
-            and self._scope.variable_name is not None
-            and len(node.targets) == 1
-            and isinstance(node.targets[0], ast.Attribute)
-            and isinstance(node.targets[0].value, ast.Name)
-            and node.targets[0].value.id == self._scope.variable_name
-            and node.targets[0].attr == "shield"
-            and isinstance(node.value, ast.Constant)
-        ):
-            self._scope.shielded = node.value.value
-        self.generic_visit(node)
-
-    def visit_Await(self, node: ast.Await) -> None:
-        # if we're inside a finally, and not inside a context_manager, and we're either not in a scope, or in a scope that doesn't have both a timeout and shield
-        if (
-            self._inside_finally is not None
-            and not self._context_manager
-            and (
-                self._scope is None
-                or (
-                    self._scope is not None
-                    and not (self._scope.timeout and self._scope.shielded)
-                )
-            )
-        ):
-            self.problems.append(make_error(TRIO102, node.lineno, node.col_offset))
-        self.generic_visit(node)
-
-    def visit_With(self, node: ast.With) -> None:
-        self.visit_generic_with(node)
 
     def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
-        self.visit_generic_with(node)
+        self.visit_With(node)
 
-    def visit_generic_FunctionDef(
+    def visit_FunctionDef(
         self, node: Union[ast.FunctionDef, ast.AsyncFunctionDef]
-    ):
+    ) -> None:
         outer_cm = self._context_manager
         outer_yie = self._yield_is_error
         self._yield_is_error = False
@@ -171,34 +226,19 @@ class Visitor(ast.NodeVisitor):
             for d in node.decorator_list
         ):
             self._context_manager = True
+
         self.generic_visit(node)
         self._context_manager = outer_cm
         self._yield_is_error = outer_yie
 
-    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
-        self.visit_generic_FunctionDef(node)
-
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
-        self.visit_generic_FunctionDef(node)
+        self.visit_FunctionDef(node)
 
     def visit_Yield(self, node: ast.Yield) -> None:
         if self._yield_is_error:
             self.problems.append(make_error(TRIO101, node.lineno, node.col_offset))
 
         self.generic_visit(node)
-
-    def visit_Try(self, node: ast.Try) -> None:
-        # There's no visit_Finally, so we need to manually visit the Try fields.
-        # It's important to do self.visit instead of self.generic_visit since
-        # the nodes in the fields might be registered elsewhere in this class.
-        for item in (*node.body, *node.handlers, *node.orelse):
-            self.visit(item)
-
-        outer = self._inside_finally
-        self._inside_finally = node
-        for item in node.finalbody:
-            self.visit(item)
-        self._inside_finally = outer
 
     def check_for_trio100(self, node: Union[ast.With, ast.AsyncWith]) -> None:
         # Context manager with no `await` call within
@@ -226,9 +266,10 @@ class Plugin:
         return cls(ast.parse(source))
 
     def run(self) -> Generator[Tuple[int, int, str, Type[Any]], None, None]:
-        visitor = Visitor()
-        visitor.visit(self._tree)
-        yield from visitor.problems
+        for v in (Visitor, Visitor102):
+            visitor = v()
+            visitor.visit(self._tree)
+            yield from visitor.problems
 
 
 TRIO100 = "TRIO100: {} context contains no checkpoints, add `await trio.sleep(0)`"

--- a/flake8_trio.py
+++ b/flake8_trio.py
@@ -35,7 +35,33 @@ def make_error(error: str, lineno: int, col: int, *args: Any, **kwargs: Any) -> 
     return (lineno, col, error.format(*args, **kwargs), type(Plugin))
 
 
-def is_trio_call(node: ast.AST, *names: str) -> Optional[str]:
+class TrioScope:
+    def __init__(self, node: ast.Call, funcname: str, packagename: str):
+        self.node = node
+        self.funcname = funcname
+        self.packagename = packagename
+        self.variable_name: Optional[str] = None
+        self.shielded: bool = False
+        self.timeout: bool = False
+        if self.funcname == "CancelScope":
+            for kw in node.keywords:
+                # Only accepts constant values
+                if kw.arg == "shield" and isinstance(kw.value, ast.Constant):
+                    self.shielded = kw.value.value
+                # sets to True even if timeout is explicitly set to inf
+                if kw.arg == "deadline":
+                    self.timeout = True
+        else:
+            self.timeout = True
+
+    def __str__(self):
+        # Not supporting other trio imports
+        # if self.packagename is None:
+            # return self.funcname
+        return f"{self.packagename}.{self.funcname}"
+
+
+def get_trio_scope(node: ast.AST, *names: str) -> Optional[TrioScope]:
     if (
         isinstance(node, ast.Call)
         and isinstance(node.func, ast.Attribute)
@@ -43,7 +69,8 @@ def is_trio_call(node: ast.AST, *names: str) -> Optional[str]:
         and node.func.value.id == "trio"
         and node.func.attr in names
     ):
-        return "trio." + node.func.attr
+        # return "trio." + node.func.attr
+        return TrioScope(node, node.func.attr, node.func.value.id)
     return None
 
 
@@ -54,21 +81,72 @@ class Visitor(ast.NodeVisitor):
         self.safe_yields: Set[ast.Yield] = set()
         self._yield_is_error = False
         self._context_manager = False
+        self._inside_finally: Optional[ast.Try] = None
+        self._scope: Optional[TrioScope] = None
 
     def visit_generic_with(self, node: Union[ast.With, ast.AsyncWith]):
         self.check_for_trio100(node)
 
-        outer = self._yield_is_error
-        if not self._context_manager and any(
-            is_trio_call(item, "open_nursery", *cancel_scope_names)
-            for item in (i.context_expr for i in node.items)
-        ):
-            self._yield_is_error = True
-
+        outer_yie = self._yield_is_error
+        outer_scope = self._scope
+        trio_scope = next(
+            (
+                get_trio_scope(item, "open_nursery", *cancel_scope_names)
+                for item in (i.context_expr for i in node.items)
+            ),
+            None,
+        )
+        if trio_scope is not None:
+            if not self._context_manager:
+                self._yield_is_error = True
+            trio_scope.variable_name = next(
+                (
+                    item.optional_vars.id
+                    for item in node.items
+                    if isinstance(item.optional_vars, ast.Name)
+                ),
+                None,
+            )
+            self._scope = trio_scope
         self.generic_visit(node)
-        self._yield_is_error = outer
+
+        # reset scope and yield_is_error
+        self._yield_is_error = outer_yie
+        self._scope = outer_scope
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        # checks for <scopename>.shield = [True/False]
+        if (
+            self._scope
+            and self._scope.variable_name is not None
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Attribute)
+            and isinstance(node.targets[0].value, ast.Name)
+            and node.targets[0].value.id == self._scope.variable_name
+            and node.targets[0].attr == "shield"
+            and isinstance(node.value, ast.Constant)
+        ):
+            self._scope.shielded = node.value.value
+        self.generic_visit(node)
+
+    def visit_Await(self, node: ast.Await) -> None:
+        # if we're inside a finally, and not inside a context_manager, and we're in a scope, and it doesn't have both a timeout and shield
+        if (
+            self._inside_finally is not None
+            and not self._context_manager
+            and (
+                self._scope is None
+                or (
+                    self._scope is not None
+                    and not (self._scope.timeout and self._scope.shielded)
+                )
+            )
+        ):
+            self.problems.append(make_error(TRIO102, node.lineno, node.col_offset))
+        self.generic_visit(node)
 
     def visit_With(self, node: ast.With) -> None:
+        # print('poop')
         self.visit_generic_with(node)
 
     def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
@@ -103,87 +181,25 @@ class Visitor(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_Try(self, node: ast.Try) -> None:
-        self.check_for_trio102(node)
-        self.generic_visit(node)
+        # There's no visit_Finally, so we need to manually visit the Try fields.
+        # It's important to do self.visit instead of self.generic_visit since
+        # the nodes in the fields might be registered elsewhere in this class.
+        for item in *node.body, *node.handlers, *node.orelse:
+            self.visit(item)
+
+        outer = self._inside_finally
+        self._inside_finally = node
+        for item in node.finalbody:
+            self.visit(item)
+        self._inside_finally = outer
 
     def check_for_trio100(self, node: Union[ast.With, ast.AsyncWith]) -> None:
         # Context manager with no `await` call within
         for item in (i.context_expr for i in node.items):
-            call = is_trio_call(item, *cancel_scope_names)
+            call = get_trio_scope(item, *cancel_scope_names)
             if call and not any(isinstance(x, ast.Await) for x in ast.walk(node)):
                 self.problems.append(
                     make_error(TRIO100, item.lineno, item.col_offset, call)
-                )
-
-    def check_for_trio102(self, node: ast.Try) -> None:
-        safe_awaits: Set[ast.Await] = set()
-        # find safe awaits
-        for item in node.finalbody:
-            for withnode in (x for x in ast.walk(item) if isinstance(x, ast.With)):
-                for withitem in withnode.items:
-                    # check there is a cancel scope
-                    if not is_trio_call(
-                        withitem.context_expr,
-                        "fail_after",
-                        "move_on_after",
-                        "fail_at",
-                        "move_on_at",
-                    ):
-                        continue
-
-                    # check for timeout
-                    # assume that if any non-kw parameter is passed, there's a timeout value
-                    if not (
-                        isinstance(withitem.context_expr, ast.Call)
-                        and (
-                            (withitem.context_expr.args)
-                            or any(
-                                kw
-                                for kw in withitem.context_expr.keywords
-                                if kw.arg == "deadline"
-                            )
-                        )
-                    ):
-                        continue
-
-                    # check that the context is saved in a variable
-                    if not (
-                        withitem.optional_vars
-                        and isinstance(withitem.optional_vars, ast.Name)
-                    ):
-                        continue
-
-                    # save the variable name
-                    scopename = withitem.optional_vars.id
-
-                    shielded = False
-                    for stmt in withnode.body:
-                        for walknode in ast.walk(stmt):
-                            # update shielded value
-                            if (
-                                isinstance(walknode, ast.Assign)
-                                and walknode.targets
-                                and isinstance(walknode.targets[0], ast.Attribute)
-                                and isinstance(walknode.targets[0].value, ast.Name)
-                                and walknode.targets[0].value.id == scopename
-                                and isinstance(walknode.value, ast.Constant)
-                            ):
-                                shielded = walknode.value.value
-
-                            # mark awaits as safe
-                            if isinstance(walknode, ast.Await) and shielded:
-                                safe_awaits.add(walknode)
-
-        # report unsafe awaits
-        # TODO: reports duplicates with nested try's atm.
-        for item in node.finalbody:
-            for awaitnode in (
-                x
-                for x in ast.walk(item)
-                if isinstance(x, ast.Await) and x not in safe_awaits
-            ):
-                self.problems.append(
-                    make_error(TRIO102, awaitnode.lineno, awaitnode.col_offset)
                 )
 
 

--- a/tests/test_flake8_trio.py
+++ b/tests/test_flake8_trio.py
@@ -60,6 +60,10 @@ class Flake8TrioTestCase(unittest.TestCase):
             make_error(TRIO102, 75, 12),
             make_error(TRIO102, 79, 12),
             make_error(TRIO102, 81, 12),
+            make_error(TRIO102, 85, 12),
+            make_error(TRIO102, 87, 12),
+            make_error(TRIO102, 89, 12),
+            make_error(TRIO102, 93, 12),
         )
 
 

--- a/tests/test_flake8_trio.py
+++ b/tests/test_flake8_trio.py
@@ -56,14 +56,24 @@ class Flake8TrioTestCase(unittest.TestCase):
             make_error(TRIO102, 22, 8),
             make_error(TRIO102, 28, 12),
             make_error(TRIO102, 34, 12),
-            make_error(TRIO102, 67, 12),
-            make_error(TRIO102, 75, 12),
-            make_error(TRIO102, 79, 12),
-            make_error(TRIO102, 81, 12),
-            make_error(TRIO102, 85, 12),
-            make_error(TRIO102, 87, 12),
-            make_error(TRIO102, 89, 12),
-            make_error(TRIO102, 93, 12),
+            make_error(TRIO102, 60, 12),
+            make_error(TRIO102, 68, 12),
+            make_error(TRIO102, 72, 12),
+            make_error(TRIO102, 74, 12),
+            make_error(TRIO102, 78, 12),
+            make_error(TRIO102, 80, 12),
+            make_error(TRIO102, 82, 12),
+            make_error(TRIO102, 86, 12),
+            make_error(TRIO102, 90, 8),
+            make_error(TRIO102, 92, 8),
+            make_error(TRIO102, 99, 12),
+        )
+
+    @unittest.skipIf(sys.version_info < (3, 9), "requires 3.9+")
+    def test_trio102_py39(self):
+        self.assert_expected_errors(
+            "trio102_py39.py",
+            make_error(TRIO102, 15, 12),
         )
 
 

--- a/tests/test_flake8_trio.py
+++ b/tests/test_flake8_trio.py
@@ -48,25 +48,26 @@ class Flake8TrioTestCase(unittest.TestCase):
             make_error(TRIO101, 15, 8),
             make_error(TRIO101, 27, 8),
             make_error(TRIO101, 38, 8),
+            make_error(TRIO101, 59, 8),
         )
 
     def test_trio102(self):
         self.assert_expected_errors(
             "trio102.py",
-            make_error(TRIO102, 22, 8),
-            make_error(TRIO102, 28, 12),
-            make_error(TRIO102, 34, 12),
-            make_error(TRIO102, 60, 12),
-            make_error(TRIO102, 68, 12),
-            make_error(TRIO102, 72, 12),
+            make_error(TRIO102, 24, 8),
+            make_error(TRIO102, 30, 12),
+            make_error(TRIO102, 36, 12),
+            make_error(TRIO102, 62, 12),
+            make_error(TRIO102, 70, 12),
             make_error(TRIO102, 74, 12),
-            make_error(TRIO102, 78, 12),
+            make_error(TRIO102, 76, 12),
             make_error(TRIO102, 80, 12),
             make_error(TRIO102, 82, 12),
-            make_error(TRIO102, 86, 12),
-            make_error(TRIO102, 90, 8),
+            make_error(TRIO102, 84, 12),
+            make_error(TRIO102, 88, 12),
             make_error(TRIO102, 92, 8),
-            make_error(TRIO102, 99, 12),
+            make_error(TRIO102, 94, 8),
+            make_error(TRIO102, 101, 12),
         )
 
     @unittest.skipIf(sys.version_info < (3, 9), "requires 3.9+")

--- a/tests/test_flake8_trio.py
+++ b/tests/test_flake8_trio.py
@@ -9,7 +9,7 @@ import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesmith import from_grammar
 
-from flake8_trio import TRIO100, Error, Plugin, Visitor, make_error
+from flake8_trio import TRIO100, TRIO102, Error, Plugin, Visitor, make_error
 
 
 class Flake8TrioTestCase(unittest.TestCase):
@@ -38,6 +38,18 @@ class Flake8TrioTestCase(unittest.TestCase):
             make_error(TRIO100, 7, 8, "trio.fail_after"),
             make_error(TRIO100, 12, 8, "trio.fail_after"),
             make_error(TRIO100, 14, 8, "trio.move_on_after"),
+        )
+
+    def test_trio102(self):
+        self.assert_expected_errors(
+            "trio102.py",
+            make_error(TRIO102, 22, 8),
+            make_error(TRIO102, 28, 12),
+            make_error(TRIO102, 34, 12),
+            make_error(TRIO102, 67, 12),
+            make_error(TRIO102, 75, 12),
+            make_error(TRIO102, 79, 12),
+            make_error(TRIO102, 81, 12),
         )
 
 

--- a/tests/trio101.py
+++ b/tests/trio101.py
@@ -1,6 +1,6 @@
 import contextlib
 import contextlib as bla
-from contextlib import asynccontextmanager, contextmanager
+from contextlib import asynccontextmanager, contextmanager, contextmanager as blahabla
 
 import trio
 
@@ -51,3 +51,9 @@ async def foo7():
 def foo8():
     with trio.open_nursery() as _:
         yield 1  # safe
+
+
+@blahabla
+def foo9():
+    with trio.open_nursery() as _:
+        yield 1  # error

--- a/tests/trio102.py
+++ b/tests/trio102.py
@@ -1,3 +1,5 @@
+from contextlib import asynccontextmanager
+
 import trio
 
 
@@ -97,3 +99,11 @@ async def foo():
             pass
         finally:
             await foo()  # error
+
+
+@asynccontextmanager
+async def foo4():
+    try:
+        yield 1
+    finally:
+        await foo()  # safe

--- a/tests/trio102.py
+++ b/tests/trio102.py
@@ -1,0 +1,81 @@
+import trio
+
+
+async def foo():
+    try:
+        pass
+    finally:
+        with trio.move_on_after(deadline=30) as s:
+            s.shield = True
+            await foo()
+
+    try:
+        pass
+    finally:
+        with trio.move_on_after(30) as s:
+            s.shield = True
+            await foo()
+
+    try:
+        pass
+    finally:
+        await foo()  # error
+
+    try:
+        pass
+    finally:
+        with trio.move_on_after(30) as s:
+            await foo()  # error
+
+    try:
+        pass
+    finally:
+        with trio.move_on_after(30):
+            await foo()  # error
+
+    try:
+        pass
+    finally:
+        with trio.move_on_after(30) as s, trio.fail_after(5):
+            s.shield = True
+            await foo()  # error?
+
+    bar = 10
+
+    try:
+        pass
+    finally:
+        with trio.move_on_after(bar) as s:
+            s.shield = True
+            await foo()
+
+    try:
+        pass
+    finally:
+        with trio.move_on_after(bar) as s:
+            s.shield = False
+            s.shield = True
+            await foo()
+
+    try:
+        pass
+    finally:
+        with trio.move_on_after(bar) as s:
+            s.shield = True
+            await foo()
+            s.shield = False
+            await foo()  # error
+            s.shield = True
+            await foo()
+
+    try:
+        pass
+    finally:
+        with open("bar"):
+            await foo()
+        with open("bar"):
+            pass
+        with trio.move_on_after():
+            await foo()
+        with trio.move_on_after(foo=bar):
+            await foo()

--- a/tests/trio102_py39.py
+++ b/tests/trio102_py39.py
@@ -1,0 +1,15 @@
+import trio
+
+
+async def foo():
+    try:
+        pass
+    finally:
+        with trio.move_on_after(30) as s, trio.fail_after(5):
+            s.shield = True
+            await foo()  # safe
+        with open(""), trio.CancelScope(deadline=30, shield=True):
+            await foo()  # safe
+        with trio.fail_after(5), trio.move_on_after(30) as s:
+            s.shield = True
+            await foo()  # safe in theory, but we don't bother parsing


### PR DESCRIPTION
A first draft of trio102. check_for_102 is kind of a mess, with having to inspect a lot of places to find cancel scopes, if they have a timeout specified, and if shielding is set. (It appears there was a shield parameter in the past that now is gone?). It might be a bit defensive and checking the parameter of the trio call is probably silly since they require one.

It also fails on fuzzing site code, since they do have `await`'s in `finally`'s and this doesn't care if they're related much to trio at all. Maybe add a global check that the file has to import or mention trio?

`trio102.py` has a fun case on line 39 (that will fail on python3.8 atm) that idk if it's worth caring about?

And it adds duplicates and is generally kinda ugly, but thought I'd push a first draft to see if I've understood the check correctly and so.