### PR TITLE
generate test environments for 3.8, 3.9 and 3.10

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,9 @@ To run our test suite please use tox.
 # Formatting and Linting
 tox -e check
 # Test Running
-tox -e test
+tox -e py310-test
+# Run checks and all tests
+tox -e ALL
 ```
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,9 +18,9 @@ To run our test suite please use tox.
 # Formatting and Linting
 tox -e check
 # Test Running
-tox -e py310-test
-# Run checks and all tests
-tox -e ALL
+tox -e test
+# Run checks and tests against Python 3.8, 3.9 and 3.10, in parallell
+tox -e ALL -p
 ```
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,10 @@ To run our test suite please use tox.
 tox -e check
 # Test Running
 tox -e test
-# Run checks and tests against Python 3.8, 3.9 and 3.10, in parallell
-tox -e ALL -p
+# Run checks and tests against Python 3.8, 3.9 and 3.10
+tox -e ALL
+# Tip: Use -p (run tests in parallel) and --develop (install package with -e) to save time when modifying and rerunning
+tox -e ALL -p --develop
 ```
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,8 @@
 # The test environment and commands
 [tox]
+# default environments to run without `-e`
+# `tox -e ALL` runs all environments
+envlist = check, py310-test
 
 [testenv:check]
 description = Format code and run linters (quick)

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 [tox]
 # default environments to run without `-e`
 # `tox -e ALL` runs all environments
-envlist = check, py310-test
+envlist = check, test
 
 [testenv:check]
 description = Format code and run linters (quick)
@@ -26,7 +26,8 @@ commands =
     flake8 --exclude .*,tests/trio*.py
     pyright --pythonversion 3.10
 
-[testenv:{py38, py39, py310}-test]
+# generate py38-test py39-test and test
+[testenv:{py38-, py39-,}test]
 description = Runs pytest, optionally with posargs
 deps =
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ commands =
     flake8 --exclude .*,tests/trio*.py
     pyright --pythonversion 3.10
 
-[testenv:test]
+[testenv:{py38, py39, py310}-test]
 description = Runs pytest, optionally with posargs
 deps =
     pytest


### PR DESCRIPTION
To save the pain of pushing code only to have it fail on github CI version tests I looked up how to set up tests against different environments directly in tox, and this works well. Added a default envlist so `tox` doesn't take forever.
With this you'll have to slightly change the CI calls (e.g. `-e py38-test` in the python3.8 test environment).

I noticed you said 3.7 -- 3.11 back in your e-mail though. Running the code against 3.11 takes forever and a library uses a deprecated feature that fails the test, so that seems not worth it. But wanted to double-check whether you want to test against 3.7 or not.