### PR TITLE
pylint pass

### DIFF
--- a/flake8_trio.py
+++ b/flake8_trio.py
@@ -19,15 +19,30 @@ __version__ = "22.8.4"
 
 Error_codes = {
     "TRIO100": "{} context contains no checkpoints, add `await trio.sleep(0)`",
-    "TRIO101": "yield inside a nursery or cancel scope is only safe when implementing a context manager - otherwise, it breaks exception handling",
-    "TRIO102": "await inside {0.name} on line {0.lineno} must have shielded cancel scope with a timeout",
+    "TRIO101": (
+        "yield inside a nursery or cancel scope is only safe when implementing "
+        "a context manager - otherwise, it breaks exception handling"
+    ),
+    "TRIO102": (
+        "await inside {0.name} on line {0.lineno} must have shielded cancel "
+        "scope with a timeout"
+    ),
     "TRIO103": "{} block with a code path that doesn't re-raise the error",
     "TRIO104": "Cancelled (and therefore BaseException) must be re-raised",
     "TRIO105": "trio async function {} must be immediately awaited",
     "TRIO106": "trio must be imported with `import trio` for the linter to work",
-    "TRIO107": "{0} from async function with no guaranteed checkpoint or exception since function definition on line {1.lineno}",
-    "TRIO108": "{0} from async iterable with no guaranteed checkpoint since {1.name} on line {1.lineno}",
-    "TRIO109": "Async function definition with a `timeout` parameter - use `trio.[fail/move_on]_[after/at]` instead",
+    "TRIO107": (
+        "{0} from async function with no guaranteed checkpoint or exception "
+        "since function definition on line {1.lineno}"
+    ),
+    "TRIO108": (
+        "{0} from async iterable with no guaranteed checkpoint since {1.name} "
+        "on line {1.lineno}"
+    ),
+    "TRIO109": (
+        "Async function definition with a `timeout` parameter - use "
+        "`trio.[fail/move_on]_[after/at]` instead"
+    ),
     "TRIO110": "`while <condition>: await trio.sleep()` should be replaced by a `trio.Event`.",
 }
 
@@ -298,16 +313,15 @@ def critical_except(node: ast.ExceptHandler) -> Optional[Statement]:
     if node.type is None:
         return Statement("bare except", node.lineno, node.col_offset)
     # several exceptions
-    elif isinstance(node.type, ast.Tuple):
+    if isinstance(node.type, ast.Tuple):
         for element in node.type.elts:
             name = has_exception(element)
             if name:
                 return Statement(name, element.lineno, element.col_offset)
     # single exception, either a Name or an Attribute
-    else:
-        name = has_exception(node.type)
-        if name:
-            return Statement(name, node.type.lineno, node.type.col_offset)
+    name = has_exception(node.type)
+    if name:
+        return Statement(name, node.type.lineno, node.type.col_offset)
     return None
 
 

--- a/tests/test_changelog_and_version.py
+++ b/tests/test_changelog_and_version.py
@@ -20,7 +20,7 @@ class Version(NamedTuple):
 
 def get_releases() -> Iterable[Version]:
     valid_pattern = re.compile(r"^## (\d\d\.\d?\d\.\d?\d)$")
-    with open(Path(__file__).parent.parent / "CHANGELOG.md") as f:
+    with open(Path(__file__).parent.parent / "CHANGELOG.md", encoding="utf-8") as f:
         lines = f.readlines()
     for aline in lines:
         version_match = valid_pattern.match(aline)
@@ -54,7 +54,7 @@ class test_messages_documented(unittest.TestCase):
             "CHANGELOG.md",
             "README.md",
         ):
-            with open(Path(__file__).parent.parent / filename) as f:
+            with open(Path(__file__).parent.parent / filename, encoding="utf-8") as f:
                 lines = f.readlines()
             documented_errors[filename] = set()
             for line in lines:

--- a/tests/test_flake8_trio.py
+++ b/tests/test_flake8_trio.py
@@ -28,9 +28,8 @@ class ParseError(Exception):
     ...
 
 
-@pytest.mark.parametrize("test, path", test_files)
-def test_eval(test: str, path: str):
-    # version check
+# check for presence of _pyXX, skip if version is later, and prune parameter
+def check_version(test: str) -> str:
     python_version = re.search(r"(?<=_PY)\d*", test)
     if python_version:
         version_str = python_version.group()
@@ -38,13 +37,20 @@ def test_eval(test: str, path: str):
         v_i = sys.version_info
         if (v_i.major, v_i.minor) < (int(major), int(minor)):
             raise unittest.SkipTest("v_i, major, minor")
-        test = test.split("_")[0]
+        return test.split("_")[0]
+    return test
+
+
+@pytest.mark.parametrize("test, path", test_files)
+def test_eval(test: str, path: str):
+    # version check
+    test = check_version(test)
 
     assert test in Error_codes.keys(), "error code not defined in flake8_trio.py"
 
     include = [test]
     expected: List[Error] = []
-    with open(os.path.join("tests", path)) as file:
+    with open(os.path.join("tests", path), encoding="utf-8") as file:
         lines = file.readlines()
 
     for lineno, line in enumerate(lines, start=1):
@@ -191,7 +197,7 @@ def assert_correct_lines_and_codes(errors: Iterable[Error], expected: Iterable[E
     for line in all_lines:
         if error_dict[line] == expected_dict[line]:
             continue
-        for code in {*error_dict[line], *expected_dict[line]}:
+        for code in sorted({*error_dict[line], *expected_dict[line]}):
             if not any_error:
                 print(
                     "Lines with different # of errors:",

--- a/tests/trio103.py
+++ b/tests/trio103.py
@@ -15,15 +15,6 @@ except trio.Cancelled as e:
 except trio.Cancelled:  # error: 7, "trio.Cancelled"
     pass
 
-# raise different exception
-except BaseException:
-    raise ValueError()  # TRIO104
-except trio.Cancelled as e:
-    raise ValueError() from e  # TRIO104
-except trio.Cancelled as e:
-    # see https://github.com/Zac-HD/flake8-trio/pull/8#discussion_r932737341
-    raise BaseException() from e  # TRIO104
-
 # if
 except BaseException as e:  # error: 7, "BaseException"
     if True:


### PR DESCRIPTION
Looks like there's bugs in both mypy and pylint with regards to the `__eq__` in Statement in flake8_trio.py (nobody mentions NamedTuple in https://github.com/python/mypy/issues/6910 - but I think it's the same?), and while the pylint issue https://github.com/PyCQA/pylint/issues/225 is closed it's cropping up in `checkpoint_continue/break` as well.
But with 11 disabled flags flake8_trio and tests/test* now pass without any errors - though if pylint was added to tox a few of those would probably be `#pylint: disable=XXX` instead.

I elected to explicitly set encoding in all opens as well, according to https://peps.python.org/pep-0597/

I also wiped a redundant test after running `pylint --disable=all --enable=similarities tests/trio*` - but that also gives a bunch of false positives. Though I am tempted to merge 103&104, and instead of doing `#error:` to mark errors do `#TRIO\d\d\d:`. I think this would also allow more `#INCLUDE` (or rather, change it to `#EXCLUDE` and only use that when necessary) and that might catch more stuff that's missing an explicit check.