### PR TITLE
fix 108 yields raising error in sync functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 *[CalVer, YY.month.patch](https://calver.org/)*
 
+## Future
+- Fix TRIO108 raising errors on yields in some sync code.
+
 ## 22.8.3
 - TRIO108 now gives multiple error messages; one for each path lacking a guaranteed checkpoint
 

--- a/tests/trio108.py
+++ b/tests/trio108.py
@@ -494,16 +494,40 @@ async def foo_ifexp_2():  # error: 0, "exit", Statement("yield", lineno+2)
 
 
 # normal function
-def foo_normal_func_1():
+def foo_sync_1():
     return
 
 
-def foo_normal_func_2():
+def foo_sync_2():
     ...
 
 
-def foo_normal_func_3():
+def foo_sync_3():
     yield
+
+
+def foo_sync_4():
+    if ...:
+        return
+    yield
+
+
+def foo_sync_5():
+    if ...:
+        return
+    yield
+
+
+def foo_sync_6():
+    while ...:
+        yield
+
+
+def foo_sync_7():
+    while ...:
+        if ...:
+            return
+        yield
 
 
 # nested function definition


### PR DESCRIPTION
Fixes (part of) #29

Should also speed up checker on sync code

Also double checked if any of the other codes that should only raise on async might run on sync, and it should not be possible.