### PR TITLE
TRIO109: skip decorated functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 *[CalVer, YY.month.patch](https://calver.org/)*
 
-## Future
+## 22.8.4
 - Fix TRIO108 raising errors on yields in some sync code.
+- TRIO109 now skips all decorated functions to avoid false alarms
 
 ## 22.8.3
 - TRIO108 now gives multiple error messages; one for each path lacking a guaranteed checkpoint

--- a/flake8_trio.py
+++ b/flake8_trio.py
@@ -14,7 +14,7 @@ import tokenize
 from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Set, Union
 
 # CalVer: YY.month.patch, e.g. first release of July 2022 == "22.7.1"
-__version__ = "22.8.3"
+__version__ = "22.8.4"
 
 
 Error_codes = {
@@ -236,7 +236,7 @@ class VisitorMiscChecks(Flake8TrioVisitor):
 
     # ---- 101, 109 ----
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef):
-        self.check_109(node.args)
+        self.check_109(node)
         self.visit_FunctionDef(node)
 
     # ---- 101 ----
@@ -247,7 +247,10 @@ class VisitorMiscChecks(Flake8TrioVisitor):
         self.generic_visit(node)
 
     # ---- 109 ----
-    def check_109(self, args: ast.arguments):
+    def check_109(self, node: ast.AsyncFunctionDef):
+        if node.decorator_list:
+            return
+        args = node.args
         for arg in (*args.posonlyargs, *args.args, *args.kwonlyargs):
             if arg.arg == "timeout":
                 self.error("TRIO109", arg)

--- a/tests/trio109.py
+++ b/tests/trio109.py
@@ -1,3 +1,5 @@
+import trio as anything
+
 timeout = 10
 
 
@@ -75,4 +77,20 @@ def foo_11(timeout, /):
 
 
 def foo_12(*, timeout):
+    ...
+
+
+# ignore all functions with a decorator
+@anything.anything
+async def foo_decorator_1(timeout):
+    ...
+
+
+@anything.anything
+async def foo_decorator_2(*, timeout):
+    ...
+
+
+@anything
+async def foo_decorator_3(timeout, /):
     ...


### PR DESCRIPTION
Fix #24 

Sort of feels like there should be a flag/config option for this though