### PR TITLE
allow other specified errors in test file

### DIFF
--- a/tests/test_flake8_trio.py
+++ b/tests/test_flake8_trio.py
@@ -66,15 +66,15 @@ def test_eval(test: str, path: str):
             continue
 
         # get text between `error:` and (end of line or another comment)
-        k = re.findall(r"(?<=error:)[^#]*(?=#|$)", line)
+        k = re.findall(r"(error|TRIO...):([^#]*)(?=#|$)", line)
 
-        for reg_match in k:
+        for err_code, err_args in k:
             try:
                 # Append a bunch of empty strings so string formatting gives garbage
                 # instead of throwing an exception
                 try:
                     args = eval(
-                        f"[{reg_match}]",
+                        f"[{err_args}]",
                         {
                             "lineno": lineno,
                             "line": lineno,
@@ -99,7 +99,9 @@ def test_eval(test: str, path: str):
 
             # assert col.isdigit(), f'invalid column "{col}" @L{lineno}, in "{line}"'
             try:
-                expected.append(Error(test, lineno, int(col), *args))
+                if err_code == "error":
+                    err_code = test
+                expected.append(Error(err_code, lineno, int(col), *args))
             except AttributeError as e:
                 msg = f'Line {lineno}: Failed to format\n "{Error_codes[test]}"\nwith\n{args}'
                 raise ParseError(msg) from e


### PR DESCRIPTION
Wrote this up while finagling with 107/108 and wanted to see how much of those issues were caused by 103. Ultimately didn't keep the added comments in the 107/108 files to minimize diff, but might as well push this for future use.
So can now do e.g.
```python
# INCLUDE TRIO103 TRIO108
try:
  ...
except: # TRIO103: 0, 'bare except'
  ...
finally:
  yield # TRIO108: [...]
```
Could then also add possibility of test file not matching an error code, in case all errors in it have the code specified.