### PR TITLE
added parametrized test of all possible permutations of try with 107

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         python -m pip install --upgrade pip setuptools tox
         python -m tox --notest --recreate -e test
     - name: Run tests
-      run: python -m tox -e test -- -n auto
+      run: python -m tox -e test
 
   release:
     runs-on: ubuntu-latest

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ deps =
     hypothesmith
     trio
 commands =
-    pytest #{posargs:-n auto}
+    pytest {posargs} #{posargs:-n auto}
 
 
 # Settings for other tools


### PR DESCRIPTION
When writing #49 I got paranoid about all the possible permutations and kept adding more and more tests to the file - so bashed out this one instead.
Since it creates a couple thousand tests it might be worth putting this behind another pytest mark [and not run by default?], and/or add back `xdist`.

The test added fails since it depends on the functionality of #49