### PR TITLE
trio102 now ignores contextmanager

### DIFF
--- a/tests/trio102.py
+++ b/tests/trio102.py
@@ -136,12 +136,14 @@ async def foo():
             await foo()  # error: 12, Statement("try/finally", lineno-3)
 
 
+# change of functionality, no longer treated as safe
+# https://github.com/Zac-HD/flake8-trio/issues/54
 @asynccontextmanager
 async def foo2():
     try:
         yield 1
     finally:
-        await foo()  # safe
+        await foo()  # error: 8, Statement("try/finally", lineno-3)
 
 
 async def foo3():


### PR DESCRIPTION
Fixes #54 
Man I'm happy with the borderline overkill testing infrastructure, *so* lovely to just change the comment and have the auto-generated test updated :blush: 

Also removed `context_manager_names` directly specifying them for trio101 since it's now the only one that cares about them.