### PR TITLE
expand 105 to also check for nursery.start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 *[CalVer, YY.month.patch](https://calver.org/)*
 
+## Future
+- TRIO105 now also checks for nursery.start() and nursery.start_soon()
+
 ## 22.11.1
 - TRIO102 is no longer skipped in (async) context managers, since it's not a missing-checkpoint warning.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 *[CalVer, YY.month.patch](https://calver.org/)*
 
-## Future
-- TRIO105 now also checks for nursery.start() and nursery.start_soon()
+## 22.11.2
+- TRIO105 now also checks that you `await`ed `nursery.start()`.
 
 ## 22.11.1
 - TRIO102 is no longer skipped in (async) context managers, since it's not a missing-checkpoint warning.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install flake8-trio
   cancel scope with a timeout.
 - **TRIO103**: `except BaseException` and `except trio.Cancelled` with a code path that doesn't re-raise.
 - **TRIO104**: `Cancelled` and `BaseException` must be re-raised - when a user tries to `return` or `raise` a different exception.
-- **TRIO105**: Calling a trio async function without immediately `await`ing it. Also triggers on `.start()` and `.start()` on variables named nursery.
+- **TRIO105**: Calling a trio async function without immediately `await`ing it.
 - **TRIO106**: trio must be imported with `import trio` for the linter to work.
 - **TRIO107**: exit or `return` from async function with no guaranteed checkpoint or exception since function definition.
 - **TRIO108**: exit, yield or return from async iterable with no guaranteed checkpoint since possible function entry (yield or function definition)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install flake8-trio
   cancel scope with a timeout.
 - **TRIO103**: `except BaseException` and `except trio.Cancelled` with a code path that doesn't re-raise.
 - **TRIO104**: `Cancelled` and `BaseException` must be re-raised - when a user tries to `return` or `raise` a different exception.
-- **TRIO105**: Calling a trio async function without immediately `await`ing it.
+- **TRIO105**: Calling a trio async function without immediately `await`ing it. Also triggers on `.start()` and `.start()` on variables named nursery.
 - **TRIO106**: trio must be imported with `import trio` for the linter to work.
 - **TRIO107**: exit or `return` from async function with no guaranteed checkpoint or exception since function definition.
 - **TRIO108**: exit, yield or return from async iterable with no guaranteed checkpoint since possible function entry (yield or function definition)

--- a/flake8_trio.py
+++ b/flake8_trio.py
@@ -29,7 +29,7 @@ from typing import (
 from flake8.options.manager import OptionManager
 
 # CalVer: YY.month.patch, e.g. first release of July 2022 == "22.7.1"
-__version__ = "22.11.1"
+__version__ = "22.11.2"
 
 
 Error_codes = {
@@ -785,25 +785,22 @@ def iter_guaranteed_once(iterable: ast.expr) -> bool:
     return False
 
 
-trio_async_functions: Dict[str, Tuple[str, ...]] = {
-    "trio": (
-        "aclose_forcefully",
-        "open_file",
-        "open_ssl_over_tcp_listeners",
-        "open_ssl_over_tcp_stream",
-        "open_tcp_listeners",
-        "open_tcp_stream",
-        "open_unix_socket",
-        "run_process",
-        "serve_listeners",
-        "serve_ssl_over_tcp",
-        "serve_tcp",
-        "sleep",
-        "sleep_forever",
-        "sleep_until",
-    ),
-    "nursery": ("start", "start_soon"),
-}
+trio_async_funcs = (
+    "aclose_forcefully",
+    "open_file",
+    "open_ssl_over_tcp_listeners",
+    "open_ssl_over_tcp_stream",
+    "open_tcp_listeners",
+    "open_tcp_stream",
+    "open_unix_socket",
+    "run_process",
+    "serve_listeners",
+    "serve_ssl_over_tcp",
+    "serve_tcp",
+    "sleep",
+    "sleep_forever",
+    "sleep_until",
+)
 
 
 class Visitor105(Flake8TrioVisitor):
@@ -821,7 +818,10 @@ class Visitor105(Flake8TrioVisitor):
         if (
             isinstance(node.func, ast.Attribute)
             and isinstance(node.func.value, ast.Name)
-            and node.func.attr in trio_async_functions.get(node.func.value.id, ())
+            and (
+                (node.func.value.id == "trio" and node.func.attr in trio_async_funcs)
+                or (node.func.value.id == "nursery" and node.func.attr == "start")
+            )
             and (
                 len(self.node_stack) < 2
                 or not isinstance(self.node_stack[-2], ast.Await)

--- a/tests/trio105.py
+++ b/tests/trio105.py
@@ -52,10 +52,8 @@ async def foo():
     # issue #56
     nursery = trio.open_nursery()
     await nursery.start()
-    await nursery.start_soon()
     await nursery.start_foo()
 
     nursery.start()  # error: 4, "start"
-    nursery.start_soon()  # error: 4, "start_soon"
+    nursery.start_soon()
     nursery.start_foo()
-    nursery.sleep()

--- a/tests/trio105.py
+++ b/tests/trio105.py
@@ -48,3 +48,14 @@ async def foo():
     # it isn't supported
     k = trio.open_file()  # error: 8, "open_file"
     await k
+
+    # issue #56
+    nursery = trio.open_nursery()
+    await nursery.start()
+    await nursery.start_soon()
+    await nursery.start_foo()
+
+    nursery.start()  # error: 4, "start"
+    nursery.start_soon()  # error: 4, "start_soon"
+    nursery.start_foo()
+    nursery.sleep()


### PR DESCRIPTION
Took me a second to remember what the rest of the code in the 105 checker did, so added a corresponding comment at line 812 otherwise unrelated to this PR.

fixes #56 