### PR TITLE
add TRIO113, nursery.start_soon() in async context manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 *[CalVer, YY.month.patch](https://calver.org/)*
 
+## FUTURE
+- TRIO113 check for [nursery].start_soon(fn, ...) in context managers for fn's that take a task_status argument.
+
 ## 22.11.2
 - TRIO105 now also checks that you `await`ed `nursery.start()`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 *[CalVer, YY.month.patch](https://calver.org/)*
 
-## FUTURE
-- TRIO113 check for [nursery].start_soon(fn, ...) in context managers for fn's that take a task_status argument.
+## 22.11.3
+- Add TRIO113, prefer `await nursery.start(...)` to `nursery.start_soon()` for compatible functions when opening a context manager
 
 ## 22.11.2
 - TRIO105 now also checks that you `await`ed `nursery.start()`.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pip install flake8-trio
 - **TRIO110**: `while <condition>: await trio.sleep()` should be replaced by a `trio.Event`.
 - **TRIO111**: Variable, from context manager opened inside nursery, passed to `start[_soon]` might be invalidly accesed while in use, due to context manager closing before the nursery. This is usually a bug, and nurseries should generally be the inner-most context manager.
 - **TRIO112**: nursery body with only a call to `nursery.start[_soon]` and not passing itself as a parameter can be replaced with a regular function call.
-- **TRIO113**: using `nursery.start_soon` in a context manager means it doesn't wait for the external process to run. Consider replacing with `nursery.start`.
+- **TRIO113**: using `nursery.start_soon` in `__aenter__` doesn't wait for the task to begin. Consider replacing with `nursery.start`.
 
 
 ## Configuration
@@ -44,28 +44,25 @@ Specify a list of decorators to disable checkpointing checks for, turning off TR
 
 Decorators-to-match must be identifiers or dotted names only (not PEP-614 expressions), and will match against the name only - e.g. `foo.bar` matches `foo.bar`, `foo.bar()`, and `foo.bar(args, here)`, etc.
 
-For example:
+[You can configure `flake8` with command-line options](https://flake8.pycqa.org/en/latest/user/configuration.html),
+but we prefer using a config file. For example:
 ```
 [flake8]
-no-checkpoint-warning-decorators = mydecorator, mydecoratorpackage.checkpointing_decorators.*, ign*, *.ignore
+no-checkpoint-warning-decorators =
+  mydecorator,
+  mydecoratorpackage.checkpointing_decorators.*,
+  ign*,
+  *.ignore,
 ```
 
 
-### `--startable-methods-in-context-manager`
-Comma-separated list of method calls to enable TRIO113 warnings for. Use if you want to override the default methods the check is enabled for. Uses the same matching algorithm as `no-checkpoint-warning-decorators`.
-For example:
-```
-[flake8]
---startable-methods-in-context-manager=mylib.myfun, myfun2,mypackage.myfunlib.*
-```
-
-Defaults to `trio.run_process, trio.serve_ssl_over_tcp, trio.serve_tcp, trio.serve_listeners,*.serve`
-
-### `--extend-startable-methods-in-context-manager`
-Comma-separated list of method calls to enable TRIO113 warnings for. Use if you want to extend the list of default methods the check is enabled for. Uses the same matching algorithm as `no-checkpoint-warning-decorators`.
-
-For example
+### `startable-in-context-manager`
+Comma-separated list of methods which should be used with `.start()` when opening a context manager,
+in addition to the default `trio.run_process`, `trio.serve_tcp`, `trio.serve_ssl_over_tcp`, and
+`trio.serve_listeners`.  Uses fnmatch, like `no-checkpoint-warning-decorators`. For example:
 ```
 [flake8]
---extend-startable-methods-in-context-manager=mylib.myfun, myfun2,mypackage.myfunlib.*
+startable-methods-in-context-manager =
+  mylib.myfun,
+  myfun2,mypackage.myfunlib.*,
 ```

--- a/README.md
+++ b/README.md
@@ -35,10 +35,12 @@ pip install flake8-trio
 - **TRIO110**: `while <condition>: await trio.sleep()` should be replaced by a `trio.Event`.
 - **TRIO111**: Variable, from context manager opened inside nursery, passed to `start[_soon]` might be invalidly accesed while in use, due to context manager closing before the nursery. This is usually a bug, and nurseries should generally be the inner-most context manager.
 - **TRIO112**: nursery body with only a call to `nursery.start[_soon]` and not passing itself as a parameter can be replaced with a regular function call.
+- **TRIO113**: using `nursery.start_soon` in a context manager means it doesn't wait for the external process to run. Consider replacing with `nursery.start`.
 
 
 ## Configuration
-`no-checkpoint-warning-decorators`: Specify a list of decorators to disable checkpointing checks for, turning off TRIO107 and TRIO108 warnings for functions decorated with any decorator matching any in the list. Matching is done with [fnmatch](https://docs.python.org/3/library/fnmatch.html). Defaults to disabling for `asynccontextmanager`.
+### `no-checkpoint-warning-decorators`
+Specify a list of decorators to disable checkpointing checks for, turning off TRIO107 and TRIO108 warnings for functions decorated with any decorator matching any in the list. Matching is done with [fnmatch](https://docs.python.org/3/library/fnmatch.html). Defaults to disabling for `asynccontextmanager`.
 
 Decorators-to-match must be identifiers or dotted names only (not PEP-614 expressions), and will match against the name only - e.g. `foo.bar` matches `foo.bar`, `foo.bar()`, and `foo.bar(args, here)`, etc.
 
@@ -46,4 +48,24 @@ For example:
 ```
 [flake8]
 no-checkpoint-warning-decorators = mydecorator, mydecoratorpackage.checkpointing_decorators.*, ign*, *.ignore
+```
+
+
+### `--startable-methods-in-context-manager`
+Comma-separated list of method calls to enable TRIO113 warnings for. Use if you want to override the default methods the check is enabled for. Uses the same matching algorithm as `no-checkpoint-warning-decorators`.
+For example:
+```
+[flake8]
+--startable-methods-in-context-manager=mylib.myfun, myfun2,mypackage.myfunlib.*
+```
+
+Defaults to `trio.run_process, trio.serve_ssl_over_tcp, trio.serve_tcp, trio.serve_listeners,*.serve`
+
+### `--extend-startable-methods-in-context-manager`
+Comma-separated list of method calls to enable TRIO113 warnings for. Use if you want to extend the list of default methods the check is enabled for. Uses the same matching algorithm as `no-checkpoint-warning-decorators`.
+
+For example
+```
+[flake8]
+--extend-startable-methods-in-context-manager=mylib.myfun, myfun2,mypackage.myfunlib.*
 ```

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -6,7 +6,7 @@ from typing import Tuple
 import pytest
 from flake8.main.application import Application
 
-from flake8_trio import Error_codes, Plugin, Statement, fnmatch_decorator
+from flake8_trio import Error_codes, Plugin, Statement, fnmatch_qualified_name
 
 
 def dec_list(*decorators: str) -> ast.Module:
@@ -21,7 +21,7 @@ def dec_list(*decorators: str) -> ast.Module:
 def wrap(decorators: Tuple[str, ...], decs2: str) -> bool:
     tree = dec_list(*decorators)
     assert isinstance(tree.body[0], ast.AsyncFunctionDef)
-    return fnmatch_decorator(tree.body[0].decorator_list, decs2)
+    return fnmatch_qualified_name(tree.body[0].decorator_list, decs2)
 
 
 def test_basic():
@@ -87,6 +87,7 @@ def test_pep614():
 def test_plugin():
     tree = dec_list("app.route")
     plugin = Plugin(tree)
+    plugin.options = Namespace(no_checkpoint_warning_decorators=[])
     assert tuple(plugin.run())
 
     plugin.options = Namespace(no_checkpoint_warning_decorators=["app.route"])

--- a/tests/test_flake8_trio.py
+++ b/tests/test_flake8_trio.py
@@ -159,7 +159,12 @@ def read_file(test_file: str):
 
 def assert_expected_errors(plugin: Plugin, include: Iterable[str], *expected: Error):
     # initialize default option values
-    om = OptionManager(version="", plugin_versions="", parents=[])
+    om = OptionManager(
+        version="",
+        plugin_versions="",
+        parents=[],
+        formatter_names=["default"],  # type: ignore
+    )
     plugin.add_options(om)
     plugin.parse_options(om.parse_args(args=[""]))
 
@@ -361,16 +366,21 @@ def test_107_permutations():
 def test_113_options():
     # check that no errors are given by default
     plugin = read_file("trio113.py")
-    om = OptionManager(version="", plugin_versions="", parents=[])
+    om = OptionManager(
+        version="",
+        plugin_versions="",
+        parents=[],
+        formatter_names=["default"],  # type: ignore
+    )
     plugin.add_options(om)
     plugin.parse_options(om.parse_args(args=["--startable-in-context-manager=''"]))
-    assert not sorted(e for e in plugin.run() if e.code == "TRIO113")
+    default = {repr(e) for e in plugin.run() if e.code == "TRIO113"}
 
     # and that the expected errors are given if we empty it and then extend it
-    arg = "--startable-in-context-manager='custom_startable_function'"
+    arg = "--startable-in-context-manager=custom_startable_function"
     plugin.parse_options(om.parse_args(args=[arg]))
-    errors = sorted(e for e in plugin.run() if e.code == "TRIO113")
-    assert errors == [Error("TRIO113", 58, 8)]
+    errors = {repr(e) for e in plugin.run() if e.code == "TRIO113"} - default
+    assert errors == {repr(Error("TRIO113", 58, 8))}
 
 
 @pytest.mark.fuzz

--- a/tests/test_flake8_trio.py
+++ b/tests/test_flake8_trio.py
@@ -359,28 +359,18 @@ def test_107_permutations():
 
 
 def test_113_options():
-    # check that no errors are given if we give an empty list of startable methods
-    # (overriding the default)
+    # check that no errors are given by default
     plugin = read_file("trio113.py")
     om = OptionManager(version="", plugin_versions="", parents=[])
     plugin.add_options(om)
-    plugin.parse_options(
-        om.parse_args(args=["--startable-methods-in-context-manager=''"])
-    )
-    assert not any(sorted(e for e in plugin.run() if e.code == "TRIO113"))
+    plugin.parse_options(om.parse_args(args=["--startable-in-context-manager=''"]))
+    assert not sorted(e for e in plugin.run() if e.code == "TRIO113")
 
     # and that the expected errors are given if we empty it and then extend it
-    plugin.parse_options(
-        om.parse_args(
-            args=[
-                "--startable-methods-in-context-manager=''",
-                "--extend-startable-methods-in-context-manager=*.serve_tcp,serve",
-            ]
-        )
-    )
+    arg = "--startable-in-context-manager='custom_startable_function'"
+    plugin.parse_options(om.parse_args(args=[arg]))
     errors = sorted(e for e in plugin.run() if e.code == "TRIO113")
-    expected = [Error("TRIO113", 46, 8), Error("TRIO113", 48, 8)]
-    assert errors == expected
+    assert errors == [Error("TRIO113", 58, 8)]
 
 
 @pytest.mark.fuzz

--- a/tests/trio113.py
+++ b/tests/trio113.py
@@ -1,0 +1,77 @@
+import contextlib
+import contextlib as arbitrary_import_alias_for_contextlib
+import os
+from contextlib import asynccontextmanager
+
+import trio
+
+
+@asynccontextmanager
+async def run_sampling_profiler():
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(  # error: 8
+            trio.run_process, ["start-sampling-profiler", str(os.getpid())]
+        )
+        yield
+
+        nursery.start_soon(  # safe, it's after the first yield
+            trio.run_process, ["start-sampling-profiler", str(os.getpid())]
+        )
+
+
+async def not_cm():
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(
+            trio.run_process, ["start-sampling-profiler", str(os.getpid())]
+        )
+        yield
+
+
+class foo:
+    async def __aenter__(self):
+        async with trio.open_nursery() as nursery:
+            nursery.start_soon(  # error: 12
+                trio.run_process, ["start-sampling-profiler", str(os.getpid())]
+            )
+            yield
+
+
+nursery = anything = serve = trio  # type: ignore
+
+
+class foo2:
+    async def __aenter__(self):
+        nursery.start_soon(trio.run_process)  # error: 8
+        nursery.start_soon(trio.serve_ssl_over_tcp)  # error: 8
+        nursery.start_soon(trio.serve_tcp)  # error: 8
+        nursery.start_soon(trio.serve_listeners)  # error: 8
+        nursery.start_soon(serve)
+        nursery.start_soon(anything.serve)  # error: 8
+
+
+class foo3:
+    async def __aenter__(_a_parameter_not_named_self):
+        nursery.start_soon(trio.run_process)  # error: 8
+
+
+# safe, requires that aenter takes a single parameter
+async def __aenter__():
+    nursery.start_soon(trio.run_process)
+
+
+# this only takes a single parameter ... right? :P
+class foo4:
+    async def __aenter__(self, *, args="foo"):
+        nursery.start_soon(trio.run_process)  # error: 8
+
+
+@contextlib.asynccontextmanager
+async def contextlib_acm():
+    nursery.start_soon(trio.run_process)  # error: 4
+    yield
+
+
+@arbitrary_import_alias_for_contextlib.asynccontextmanager
+async def contextlib_import_alias_acm():
+    nursery.start_soon(trio.run_process)  # error: 4
+    yield

--- a/tests/trio113.py
+++ b/tests/trio113.py
@@ -66,6 +66,8 @@ class foo3:
 # might be monkeypatched onto an instance, count this as an error too
 async def __aenter__():
     nursery.start_soon(trio.run_process)  # error: 4
+    nursery.start_soon()  # broken code, but our analysis shouldn't crash
+    nursery.cancel_scope.cancel()
 
 
 # this only takes a single parameter ... right? :P


### PR DESCRIPTION
Fixes #57 

Quick and dirty:
* the message probably needs bettering.
* require that the object `start_soon` is called on is called "nursery"?
* require that it's also inside a `with`?
* could probs extend tests, but I think I covered most cases.
* maybe doesn't need it's own class, but since speed hasn't been an issue /shrug
* add config option