### PR TITLE
trio113&114 now only uses unqualified name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 *[CalVer, YY.month.patch](https://calver.org/)*
+## 22.12.1
+- TRIO113 now only supports names that are valid identifiers. I.e. no dots or asterisks anymore.
+- TRIO114 will now trigger on the unqualified name, will now only check the first parameterdirectly, and parameters to function calls inside that.
 
 ## 22.11.5
 - Add TRIO116: `trio.sleep()` with >24 hour interval should usually be `trio.sleep_forever()`.

--- a/README.md
+++ b/README.md
@@ -41,13 +41,15 @@ pip install flake8-trio
 
 
 ## Configuration
+[You can configure `flake8` with command-line options](https://flake8.pycqa.org/en/latest/user/configuration.html),
+but we prefer using a config file.
+
 ### `no-checkpoint-warning-decorators`
 Specify a list of decorators to disable checkpointing checks for, turning off TRIO107 and TRIO108 warnings for functions decorated with any decorator matching any in the list. Matching is done with [fnmatch](https://docs.python.org/3/library/fnmatch.html). Defaults to disabling for `asynccontextmanager`.
 
 Decorators-to-match must be identifiers or dotted names only (not PEP-614 expressions), and will match against the name only - e.g. `foo.bar` matches `foo.bar`, `foo.bar()`, and `foo.bar(args, here)`, etc.
 
-[You can configure `flake8` with command-line options](https://flake8.pycqa.org/en/latest/user/configuration.html),
-but we prefer using a config file. For example:
+For example:
 ```
 [flake8]
 no-checkpoint-warning-decorators =
@@ -61,10 +63,10 @@ no-checkpoint-warning-decorators =
 ### `startable-in-context-manager`
 Comma-separated list of methods which should be used with `.start()` when opening a context manager,
 in addition to the default `trio.run_process`, `trio.serve_tcp`, `trio.serve_ssl_over_tcp`, and
-`trio.serve_listeners`.  Uses fnmatch, like `no-checkpoint-warning-decorators`. For example:
+`trio.serve_listeners`.  Names must be valid identifiers as per `str.isidentifier()`. For example:
 ```
 [flake8]
 startable-methods-in-context-manager =
-  mylib.myfun,
-  myfun2,mypackage.myfunlib.*,
+  myfun,
+  myfun2,
 ```

--- a/tests/test_flake8_trio.py
+++ b/tests/test_flake8_trio.py
@@ -372,6 +372,7 @@ def test_113_options():
     plugin = read_file("trio113.py")
     om = _default_option_manager()
     plugin.add_options(om)
+    plugin.parse_options(om.parse_args(args=[]))
     default = {repr(e) for e in plugin.run() if e.code == "TRIO113"}
 
     # check that our custom_startable_function is detected
@@ -386,6 +387,7 @@ def test_114_options():
     plugin = read_file("trio114.py")
     om = _default_option_manager()
     plugin.add_options(om)
+    plugin.parse_options(om.parse_args(args=[]))
     default = {repr(e) for e in plugin.run() if e.code == "TRIO114"}
 
     arg = "--startable-in-context-manager=foo"
@@ -393,20 +395,12 @@ def test_114_options():
     errors = {repr(e) for e in plugin.run() if e.code == "TRIO114"}
     assert len(errors) == len(default) - 1
 
-    arg = "--startable-in-context-manager=blah.foo"
-    plugin.parse_options(om.parse_args(args=[arg]))
-    errors = {repr(e) for e in plugin.run() if e.code == "TRIO114"}
-    assert len(errors) == len(default) - 1
-
-    arg = "--startable-in-context-manager=foo*"
-    plugin.parse_options(om.parse_args(args=[arg]))
-    errors = {repr(e) for e in plugin.run() if e.code == "TRIO114"}
-    assert len(errors) == len(default) - 4
-
-    arg = "--startable-in-context-manager=*"
-    plugin.parse_options(om.parse_args(args=[arg]))
-    errors = {repr(e) for e in plugin.run() if e.code == "TRIO114"}
-    assert len(errors) == 0
+    # flake8 will reraise ArgumentError as SystemExit
+    for arg in "blah.foo", "foo*", "*":
+        with pytest.raises(SystemExit):
+            plugin.parse_options(
+                om.parse_args(args=[f"--startable-in-context-manager={arg}"])
+            )
 
 
 @pytest.mark.fuzz

--- a/tests/trio113.py
+++ b/tests/trio113.py
@@ -74,9 +74,23 @@ class foo2:
         nursery.start_soon(functools.partial(trio.run_process))  # error: 8
         nursery.start_soon(anything.partial(trio.run_process))  # error: 8
 
-        # trigger when the sensitive methods are anywhere inside the first parameter
+        # trigger when the sensitive methods are inside a call
         nursery.start_soon(tuple(tuple(tuple(tuple(trio.run_process)))))  # error: 8
         nursery.start_soon(None, tuple(tuple(tuple(tuple(trio.run_process)))))
+        nursery.start_soon(partial(print, 5))
+        nursery.start_soon(partial(print, trio.run_process))  # error: 8
+
+        serve = run_process = myfun = anything
+        # error if name shared with trio
+        nursery.start_soon(serve)  # error: 8
+        nursery.start_soon(run_process)  # error: 8
+        # don't error if a startable name is a parameter or module
+        nursery.start_soon(myfun(serve=None))
+        nursery.start_soon(serve.myfun)
+
+        # doesn't support more esoteric ways of baking in the name
+        nursery.start_soon(lambda x: serve(x))
+        nursery.start_soon([serve])
 
 
 class foo3:


### PR DESCRIPTION
fixes #72 

* was a bit tricky to get argparse to play along as I wanted, but all should now be fully working there.
* `test_113_options` and `test_114_options` are actually broken on main if they're run on their own, since they didn't run `parse_options` to populate the namespace. I haven't fully figured out why it works when they run after other tests, presumably some object is shared which might be worth fixing to avoid future/other issues. But they now parse their args.
* the behavior of 113 is maybe a bit weird, look through the test cases (particularly the ones added) to see if you find any cases that you think should/shouldn't be an error. `is_startable` is pretty easy to modify.
* I don't love having to deal with two lists of calls, might merge them somewhere - but not a big deal.
* `sync_errors` in test_flake8_trio has not been updated in a while, I think that should probably be a list of errors to ignore on sync code rather than the other way so you don't forget to expand the list.

Should otherwise be finished, maybe the error message on a bad parameter could be more helpful. 
