### PR TITLE
add trio115: use trio.lowlevel.checkpoint() instead of trio.sleep(0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 *[CalVer, YY.month.patch](https://calver.org/)*
 
+## Future
+- Add TRIO115: Use `trio.lowlevel.checkpoint()` instead of `trio.sleep(0)`.
+
 ## 22.11.5
 - Add TRIO116: `trio.sleep()` with >24 hour interval should usually be `trio.sleep_forever()`.
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ pip install flake8-trio
 - **TRIO112**: nursery body with only a call to `nursery.start[_soon]` and not passing itself as a parameter can be replaced with a regular function call.
 - **TRIO113**: using `nursery.start_soon` in `__aenter__` doesn't wait for the task to begin. Consider replacing with `nursery.start`.
 - **TRIO114**: Startable function (i.e. has a `task_status` parameter) not in `--startable-in-context-manager` parameter list, please add it so TRIO113 can catch errors when using it.
+- **TRIO115**: Replace `trio.sleep(0)` with the more suggestive `trio.lowlevel.checkpoint()`.
 - **TRIO116**: `trio.sleep()` with >24 hour interval should usually be`trio.sleep_forever()`.
 
 

--- a/tests/trio115.py
+++ b/tests/trio115.py
@@ -1,0 +1,31 @@
+import time
+
+import trio
+from trio import sleep
+
+
+async def afoo():
+    # only error on exactly one argument, that is 0
+    await trio.sleep(0)  # error: 10
+    await trio.sleep(1)
+    await trio.sleep(0, 1)
+    await trio.sleep(...)
+    await trio.sleep()
+
+    # don't require it being await'ed
+    trio.sleep(0)  # error: 4
+    trio.sleep(1)
+
+    # don't error on other sleeps
+    time.sleep(0)
+    sleep(0)
+
+
+# don't require being inside a function
+trio.sleep(0)  # error: 0
+
+
+def foo():
+    # can be inside a sync function, and inside other calls
+    # (though yes this is invalid code)
+    trio.run(trio.sleep(0))  # error: 13


### PR DESCRIPTION
I think 15 minutes to write a new check is a new record!

* I opted not to require it being in an async function or be await'ed, but can change that if you want
* feel free to suggest modifications to error message or documentation as usual
* did not update `__version__` with there being multiple open PR's