### PR TITLE
move error codes into visitor classes

### DIFF
--- a/tests/test_changelog_and_version.py
+++ b/tests/test_changelog_and_version.py
@@ -8,7 +8,7 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import NamedTuple
 
-from test_flake8_trio import trio_test_files_regex
+from test_flake8_trio import ERROR_CODES, trio_test_files_regex
 
 import flake8_trio
 
@@ -66,7 +66,7 @@ class test_messages_documented(unittest.TestCase):
                 for error_msg in re.findall(r"TRIO\d\d\d", line):
                     documented_errors[filename].add(error_msg)
 
-        documented_errors["flake8_trio.py"] = set(flake8_trio.Error_codes.keys())
+        documented_errors["flake8_trio.py"] = set(ERROR_CODES)
 
         documented_errors["tests/trio*.py"] = {
             os.path.splitext(f)[0].upper().split("_")[0]

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -5,7 +5,7 @@ import ast
 from flake8.main.application import Application
 from test_flake8_trio import _default_option_manager
 
-from flake8_trio import Error_codes, Plugin, Statement, fnmatch_qualified_name
+from flake8_trio import Plugin, Statement, Visitor107_108, fnmatch_qualified_name
 
 
 def dec_list(*decorators: str) -> ast.Module:
@@ -107,9 +107,16 @@ def test_command_line_1(capfd):
     assert not out and not err
 
 
+# expected_out = (
+#    "tests/trio_options.py:2:1: TRIO107: "
+#    + Error_codes["TRIO107"].format("exit", Statement("function definition", 2))
+#    + "\n"
+# )
 expected_out = (
     "tests/trio_options.py:2:1: TRIO107: "
-    + Error_codes["TRIO107"].format("exit", Statement("function definition", 2))
+    + Visitor107_108.error_codes["TRIO107"].format(
+        "exit", Statement("function definition", 2)
+    )
     + "\n"
 )
 

--- a/tests/trio113.py
+++ b/tests/trio113.py
@@ -7,13 +7,12 @@ from functools import partial
 
 import trio
 
+# ARGS --startable-in-context-manager=custom_startable_function
 
-# test_113_options in test_flake8_trio.py sets `startable-in-context-manager` to
-# error here using a command-line parameter.
-# Warning: requires manually changing the lineno if it changes
+
 @asynccontextmanager
 async def custom_startable_externally_tested():
-    nursery.start_soon(custom_startable_function)
+    nursery.start_soon(custom_startable_function)  # error: 4
     yield
 
 

--- a/tests/trio114.py
+++ b/tests/trio114.py
@@ -1,7 +1,9 @@
 import trio
 
+# ARGS --startable-in-context-manager=foo
 
-async def foo(task_status):  # error: 0, "foo"
+
+async def foo(task_status):
     ...
 
 


### PR DESCRIPTION
also changes test_113 and 114_options to use ARGS (since they broke from this it was a good opportunity to rewrite them).

> As a follow-up, it'd be nice for each visitor class to have a docstring briefly explaining what they do - just copying the relevant line from the readme would be plenty.

Yeah this has been sorely needed for a while, I started copy-pasting but started feeling very silly about it so the visitor classes now define their error codes themselves.
Would be fun to move the documentation from the readme into them and auto-generate docs (+ the same for command line args) as well, but that's probs overkill - although having to keep documentation correct in several different files & places is always a pain.