### PR TITLE
Config error

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Comma-separated list of methods which should be used with `.start()` when openin
 in addition to the default `trio.run_process`, `trio.serve_tcp`, `trio.serve_ssl_over_tcp`, and
 `trio.serve_listeners`.  Names must be valid identifiers as per `str.isidentifier()`. For example:
 ```
-startable-methods-in-context-manager =
+startable-in-context-manager =
   myfun,
   myfun2,
 ```

--- a/flake8_trio.py
+++ b/flake8_trio.py
@@ -1385,7 +1385,6 @@ class ParseDict(argparse.Action):
         res: dict[str, str] = {}
         splitter = "->"  # avoid ":" because it's part of .ini file syntax
         assert values is not None
-        assert option_string is not None
         for value in values:
             split_values = list(map(str.strip, value.split(splitter)))
             if len(split_values) != 2:
@@ -1414,6 +1413,15 @@ class Plugin:
         return cls(ast.parse(source))
 
     def run(self) -> Iterable[Error]:
+        # temporary workaround, since the Action does not seem to be called properly
+        # by flake8 when parsing from config
+        if isinstance(self.options.trio200_blocking_calls, list):
+            ParseDict([""], dest="trio200_blocking_calls")(
+                None,  # type: ignore
+                self.options,
+                self.options.trio200_blocking_calls,  # type: ignore
+                None,
+            )
         yield from Flake8TrioRunner.run(self._tree, self.options)
 
     @staticmethod


### PR DESCRIPTION
Very dirty workaround for #84 in case you want it fixed quickly.
Spaces in the "suggested replacement", or around `->`, are still broken.

Also noticed a typo in the readme