### PR TITLE
add pre-commit config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  check:
+  typing:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -18,11 +18,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools tox
-        python -m tox --notest --recreate -e check
-    - name: Run checks
+        python -m tox --notest --recreate -e typing
+    - name: Run type checks
       run: |
-        python -m tox -e check
-        git diff --exit-code
+        python -m tox -e typing
 
   test:
     runs-on: ubuntu-latest
@@ -45,7 +44,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [check, test]
+    needs: [typing, test]
     if: github.repository == 'Zac-HD/flake8-trio' &&  github.ref == 'refs/heads/main'
     steps:
     - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,67 @@
+ci:
+  skip: [pyright]
+
+repos:
+-   repo: https://github.com/Zac-HD/shed
+    rev: 0.10.8
+    hooks:
+    -   id: shed
+        args: ['--py39-plus']
+
+-   repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.286
+    hooks:
+    -   id: pyright
+        entry: env PYRIGHT_PYTHON_FORCE_VERSION=latest pyright
+        args: ['--pythonversion=3.11', '--warnings']
+        additional_dependencies:
+          # Required for pyright strict mode
+          - hypothesis
+          - hypothesmith
+          - pytest
+          - flake8
+
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    -   id: trailing-whitespace
+        args: ['--markdown-linebreak-ext=md,markdown']
+    -   id: end-of-file-fixer
+    -   id: fix-encoding-pragma
+        args: [--remove]
+    -   id: check-yaml
+    -   id: debug-statements
+        language_version: python3
+
+-   repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
+    hooks:
+    -   id: flake8
+        args: ["--exclude", ".*,tests/trio*.py"]
+        language_version: python3
+        additional_dependencies:
+          - flake8-builtins
+          - flake8-bugbear
+          - flake8-comprehensions
+          - flake8-2020
+          - flake8-bandit
+          - flake8-builtins
+          - flake8-bugbear
+          - flake8-comprehensions
+          - flake8-datetimez
+         #- flake8-docstrings
+          - flake8-mutable
+          - flake8-noqa
+          - flake8-pie
+          - flake8-pytest-style
+          - flake8-return
+          - flake8-simplify
+
+-   repo: https://github.com/PyCQA/flake8
+    rev: 5.0.4
+    hooks:
+    -   id: flake8
+        args: ["--exclude", ".*,tests/trio*.py", "--select=E800"]
+        language_version: python3
+        additional_dependencies:
+          - flake8-eradicate

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,6 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
             item.add_marker(skip_fuzz)
 
 
-@pytest.fixture
+@pytest.fixture()
 def enable_visitor_codes_regex(request: pytest.FixtureRequest):
     return request.config.getoption("--enable-visitor-codes-regex")

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -12,8 +12,7 @@ def dec_list(*decorators: str) -> ast.Module:
     for dec in decorators:
         source += f"@{dec}\n"
     source += "async def f():\n  bar()"
-    tree = ast.parse(source)
-    return tree
+    return ast.parse(source)
 
 
 def wrap(decorators: tuple[str, ...], decs2: str) -> str | None:
@@ -86,8 +85,7 @@ common_flags = ["--select=TRIO", "tests/trio_options.py"]
 
 def test_command_line_1(capfd):
     Application().run(common_flags + ["--no-checkpoint-warning-decorators=app.route"])
-    out, err = capfd.readouterr()
-    assert not out and not err
+    assert capfd.readouterr() == ("", "")
 
 
 expected_out = (
@@ -101,11 +99,9 @@ expected_out = (
 
 def test_command_line_2(capfd):
     Application().run(common_flags + ["--no-checkpoint-warning-decorators=app"])
-    out, err = capfd.readouterr()
-    assert out == expected_out and not err
+    assert capfd.readouterr() == (expected_out, "")
 
 
 def test_command_line_3(capfd):
     Application().run(common_flags)
-    out, err = capfd.readouterr()
-    assert out == expected_out and not err
+    assert capfd.readouterr() == (expected_out, "")

--- a/tox.ini
+++ b/tox.ini
@@ -1,36 +1,7 @@
 # The test environment and commands
 [tox]
 # default environments to run without `-e`
-envlist = check, py{39,310,311}-{flake8_5,flake8_6}
-
-[testenv:check]
-description = Format code and run linters (quick)
-deps =
-    shed
-    flake8
-    flake8-builtins
-    flake8-bugbear
-    flake8-comprehensions
-    pyright
-    # Required for pyright strict mode
-    hypothesis
-    hypothesmith
-    pytest
-    trio
-setenv =
-    # Make sure pyright is always up to date
-    PYRIGHT_PYTHON_FORCE_VERSION = latest
-skip_install =
-    # don't install the plugin, which would register it with flake8
-    # and potentially stop the linter from functioning.
-    true
-ignore_errors =
-    # true means "run all, fail if any failed"
-    true
-commands =
-    shed --py39-plus
-    flake8 --exclude .*,tests/trio*.py
-    pyright --pythonversion 3.11 --warnings
+envlist = py{39,310,311}-{flake8_5,flake8_6}
 
 # create a default testenv, whose behaviour will depend on the name it's called with.
 # for CI you can call with `-e flake8_5,flake8_6` and let the CI handle python version
@@ -48,6 +19,12 @@ deps =
 commands =
     pytest {posargs} #{posargs:-n auto}
 
+[testenv:typing]
+description = Runs pyright in pre-commit from tox for CI, since it requires an internet connection
+deps =
+    pre-commit
+commands =
+    pre-commit run pyright --all-files
 
 # Settings for other tools
 [pytest]
@@ -63,6 +40,7 @@ filterwarnings =
 
 [flake8]
 max-line-length = 90
+extend-ignore = S101
 
 [coverage:report]
 exclude_lines =


### PR DESCRIPTION
It bit me a bunch of times that I didn't run tox before pushing minor changes, and `tox -e check` takes 13s on my system, so I've gradually recreated all the functionality from it in pre-commit + some other checks. So at this point it might be worth removing `tox -e check` entirely and transitioning the CI to use pre-commit as well. If you approve of the idea I'll implement the necessary gh CI changes as well & clean up `tox.ini`.

~~(though it currently won't pass until #87 is merged)~~

TODO:
- [x] Go through https://github.com/HypothesisWorks/hypothesis/blob/226028dcf62b7c7a239574af6f5d69559be0febc/requirements/tools.in#L5-L19 and crib any nice ones.