### PR TITLE
fix flake8-noqa compatibility

### DIFF
--- a/flake8_trio.py
+++ b/flake8_trio.py
@@ -74,7 +74,7 @@ class Error:
     def __iter__(self):
         yield self.line
         yield self.col
-        yield f"{self.code}: " + self.message.format(*self.args)
+        yield f"{self.code} " + self.message.format(*self.args)
         yield type(Plugin)
 
     def cmp(self):

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -108,7 +108,7 @@ def test_command_line_1(capfd):
 
 
 expected_out = (
-    "tests/trio_options.py:2:1: TRIO107: "
+    "tests/trio_options.py:2:1: TRIO107 "
     + Visitor107_108.error_codes["TRIO107"].format(
         "exit", Statement("function definition", 2)
     )

--- a/tests/test_flake8_trio.py
+++ b/tests/test_flake8_trio.py
@@ -468,7 +468,7 @@ async def foo():
     res = subprocess.run(["flake8"], cwd=tmp_path, capture_output=True)
     assert not res.stderr
     assert res.stdout == (
-        b"./example.py:5:5: TRIO200: User-configured blocking sync call sync_fns.* "
+        b"./example.py:5:5: TRIO200 User-configured blocking sync call sync_fns.* "
         b"in async function, consider replacing with the_async_equivalent.\n"
     )
 


### PR DESCRIPTION
*Huge* PR :grin: 

Not sure why that colon was added in the first place, but the plugin now finally works with flake8-noqa's `NQA102` and `NQA103`