### PR TITLE
21X and 22X, blocking sync calls in async function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 *[CalVer, YY.month.patch](https://calver.org/)*
 
+## 23.1.1
+- Add TRIO210, TRIO211 - blocking sync call in async function, using network packages (requests, httpx, urllib3)
+- Add TRIO220, TRIO221 - blocking sync call in async function, using subprocess or os.
+
 ## 22.12.5
 - The `--startable-in-context-manager` and `--trio200-blocking-calls` options now handle spaces and newlines.
 - Now compatible with  [flake8-noqa](https://pypi.org/project/flake8-noqa/)'s NQA102 and NQA103 checks.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,13 @@ You can instead of `error` specify the error code.
 With `# ARG` lines you can also specify command-line arguments that should be passed to the plugin when parsing a file. Can be specified multiple times for several different arguments.  
 Generated tests will by default `--select` the error code of the file, which will enable any visitors that can generate that code (and if those visitors can raise other codes they might be raised too). This can be overriden by adding an `# ARG --select=...` line.
 
+## Running pytest outside tox
+If you don't want to bother with tox to quickly test stuff, you'll need to install the following dependencies:
+```
+pip install -e .
+pip install pytest pytest-cov hypothesis hypothesmith flake8
+```
+
 ## Style Guide
 
 **Code style:** code review should focus on correctness, performance, and readability.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ pip install flake8-trio
 - **TRIO115**: Replace `trio.sleep(0)` with the more suggestive `trio.lowlevel.checkpoint()`.
 - **TRIO116**: `trio.sleep()` with >24 hour interval should usually be`trio.sleep_forever()`.
 - **TRIO200**: User-configured error for blocking sync calls in async functions. Does nothing by default, see [`trio200-blocking-calls`](#trio200-blocking-calls) for how to configure it.
+- **TRIO210**: Sync HTTP call {} in async function, use `httpx.AsyncClient`.
+- **TRIO211**: Likely sync HTTP call {} in async function, use `httpx.AsyncClient`. Looks for `urllib3` method calls on pool objects, but only matching on the method signature and not the object.
+- **TRIO220**: Sync call {} in async function, use `await nursery.start(trio.run_process, ...)`.
+- **TRIO221**: Sync call {} in async function, use `await trio.run_process(...)`.
 
 
 ## Configuration

--- a/tests/trio210.py
+++ b/tests/trio210.py
@@ -1,0 +1,39 @@
+import urllib
+
+import httpx
+import requests
+import urllib3
+
+
+async def foo():
+    requests.get()  # TRIO210: 4, 'requests.get'
+    requests.get(...)  # TRIO210: 4, 'requests.get'
+    requests.get
+    print(requests.get())  # TRIO210: 10, 'requests.get'
+    # fmt: off
+    print(requests.get(requests.get()))# TRIO210: 10, 'requests.get' # TRIO210: 23, 'requests.get'
+    # fmt: on
+
+    requests.options()  # TRIO210: 4, 'requests.options'
+    requests.head()  # TRIO210: 4, 'requests.head'
+    requests.post()  # TRIO210: 4, 'requests.post'
+    requests.put()  # TRIO210: 4, 'requests.put'
+    requests.patch()  # TRIO210: 4, 'requests.patch'
+    requests.delete()  # TRIO210: 4, 'requests.delete'
+    requests.foo()
+
+    httpx.options("")  # TRIO210: 4, 'httpx.options'
+    httpx.head("")  # TRIO210: 4, 'httpx.head'
+    httpx.post("")  # TRIO210: 4, 'httpx.post'
+    httpx.put("")  # TRIO210: 4, 'httpx.put'
+    httpx.patch("")  # TRIO210: 4, 'httpx.patch'
+    httpx.delete("")  # TRIO210: 4, 'httpx.delete'
+    httpx.foo()
+
+    urllib3.request()  # TRIO210: 4, 'urllib3.request'
+    urllib3.request(...)  # TRIO210: 4, 'urllib3.request'
+    request()
+
+    urllib.request.urlopen("")  # TRIO210: 4, 'urllib.request.urlopen'
+    request.urlopen()  # TRIO210: 4, 'request.urlopen'
+    urlopen()  # TRIO210: 4, 'urlopen'

--- a/tests/trio211.py
+++ b/tests/trio211.py
@@ -1,0 +1,25 @@
+from urllib3 import PoolManager
+
+
+async def foo():
+    foo = PoolManager()
+    foo.request("OPTIONS")  # TRIO211: 4, 'foo.request'
+    foo.request("GET")  # TRIO211: 4, 'foo.request'
+    foo.request("HEAD")  # TRIO211: 4, 'foo.request'
+    foo.request("POST")  # TRIO211: 4, 'foo.request'
+    foo.request("PUT")  # TRIO211: 4, 'foo.request'
+    foo.request("DELETE")  # TRIO211: 4, 'foo.request'
+    foo.request("TRACE")  # TRIO211: 4, 'foo.request'
+    foo.request("CONNECT")  # TRIO211: 4, 'foo.request'
+    foo.request("PATCH")  # TRIO211: 4, 'foo.request'
+
+    foo.request("PUT", ...)  # TRIO211: 4, 'foo.request'
+    request("PUT")
+    foo.request()
+    foo.request(..., "PUT")
+    foo.request("put")  # TRIO211: 4, 'foo.request'
+    foo.request("sPUTnik")
+    foo.request(None)
+    foo.request(put)
+    foo.request(PUT)
+    foo.request("REQUEST")  # not an HTTP verb

--- a/tests/trio22x.py
+++ b/tests/trio22x.py
@@ -1,0 +1,53 @@
+# ARG --enable-visitor-codes-regex=(TRIO220|TRIO221)
+
+
+async def foo():
+    subprocess.Popen()  # TRIO220: 4, 'subprocess.Popen'
+    os.system()  # TRIO221: 4, 'os.system'
+
+    system()
+    os.system.anything()
+    os.anything()
+
+    subprocess.run()  # TRIO221: 4, 'subprocess.run'
+    subprocess.call()  # TRIO221: 4, 'subprocess.call'
+    subprocess.check_call()  # TRIO221: 4, 'subprocess.check_call'
+    subprocess.check_output()  # TRIO221: 4, 'subprocess.check_output'
+    subprocess.getoutput()  # TRIO221: 4, 'subprocess.getoutput'
+    subprocess.getstatusoutput()  # TRIO221: 4, 'subprocess.getstatusoutput'
+
+    subprocess.anything()
+    subprocess.foo()
+    subprocess.bar.foo()
+    subprocess()
+
+    os.spawn()
+    os.spawn
+
+    os.spawnl()  # TRIO221: 4,   'os.spawnl'
+    os.spawnle()  # TRIO221: 4,  'os.spawnle'
+    os.spawnlp()  # TRIO221: 4,  'os.spawnlp'
+    os.spawnlpe()  # TRIO221: 4, 'os.spawnlpe'
+    os.spawnv()  # TRIO221: 4,   'os.spawnv'
+    os.spawnve()  # TRIO221: 4,  'os.spawnve'
+    os.spawnvp()  # TRIO221: 4,  'os.spawnvp'
+    os.spawnvpe()  # TRIO221: 4, 'os.spawnvpe'
+
+    # if mode is given, and is not os.P_WAIT: TRIO220
+    os.spawnl(os.P_NOWAIT)  # TRIO220: 4,   'os.spawnl'
+    os.spawnl(P_NOWAIT)  # TRIO220: 4,   'os.spawnl'
+    os.spawnl(mode=os.P_NOWAIT)  # TRIO220: 4,   'os.spawnl'
+    os.spawnl(mode=P_NOWAIT)  # TRIO220: 4,   'os.spawnl'
+
+    # if it is P_WAIT, TRIO221
+    os.spawnl(os.P_WAIT)  # TRIO221: 4,   'os.spawnl'
+    os.spawnl(P_WAIT)  # TRIO221: 4,   'os.spawnl'
+    os.spawnl(mode=os.P_WAIT)  # TRIO221: 4,   'os.spawnl'
+    os.spawnl(mode=P_WAIT)  # TRIO221: 4,   'os.spawnl'
+    # treating this as 221 to simplify code, and see no real reason not to
+    os.spawnl(foo.P_WAIT)  # TRIO221: 4,   'os.spawnl'
+
+    # other weird cases: TRIO220
+    os.spawnl(0)  # TRIO220: 4,   'os.spawnl'
+    os.spawnl(1)  # TRIO220: 4,   'os.spawnl'
+    os.spawnl(foo())  # TRIO220: 4,   'os.spawnl'


### PR DESCRIPTION
Checking off the first couple sync calls in #58 

`Flake8TrioVisitor.__subclasses__` didn't do it anymore once I started using multilevel inheritance, so solved it by creating a decorator for error classes that registers them. (type hinting the decorator function was fun :sweat_smile:)

Wasn't sure if the http calls and process invocation bullet points wanted different error messages for each, and the messages themselves are kinda rough, but went with this for a first pass.

TODO:
- [x] changelog
- [ ] better readme text & error messages
- [x] os.spawn[vl]p?e? should give TRIO220 sometimes
- [x] test file shouldn't be called `trio210.py` - change regex so it can be named `trio2xx.py` or split into `trio21x.py` and `trio22x.py`

Don't bother merging both this and #91, merge one and I'll fix the conflicts in the other.