### PR TITLE
run all of pre-commit directly from the gh CI action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  typing:
+  check:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -17,11 +17,10 @@ jobs:
         python-version: "3.11"
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools tox
-        python -m tox --notest --recreate -e typing
-    - name: Run type checks
+        python -m pip install --upgrade pip setuptools pre-commit
+    - name: Run checks
       run: |
-        python -m tox -e typing
+        pre-commit run --all-files
 
   test:
     runs-on: ubuntu-latest
@@ -44,7 +43,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [typing, test]
+    needs: [check, test]
     if: github.repository == 'Zac-HD/flake8-trio' &&  github.ref == 'refs/heads/main'
     steps:
     - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+# not necessary as Zac-HD/flake8-trio don't currently run pre-commit as an app
+# but keeping it for forks, or in case that changes
 ci:
   skip: [pyright]
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,24 +19,6 @@ deps =
 commands =
     pytest {posargs} #{posargs:-n auto}
 
-[testenv:typing]
-description = Runs pyright in pre-commit from tox for CI, since it requires an internet connection
-deps =
-    pre-commit
-commands =
-    pre-commit run pyright --all-files
-
-# Settings for other tools
-[pytest]
-addopts =
-    --tb=native
-    --cov=flake8_trio
-    --cov-branch
-    --cov-report=term-missing:skip-covered
-    --cov-fail-under=100
-filterwarnings =
-    error
-
 
 [flake8]
 max-line-length = 90


### PR DESCRIPTION
Fixes #97 
Re-renamed back typing to check, and GH CI now runs all of pre-commit and not just pyright.