### PR TITLE
Add TRIO23x, sync IO call in async function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 *[CalVer, YY.month.patch](https://calver.org/)*
 
+## 23.1.2
+- Add TRIO230, TRIO231 - sync IO calls in async function
+-
 ## 23.1.1
 - Add TRIO210, TRIO211 - blocking sync call in async function, using network packages (requests, httpx, urllib3)
 - Add TRIO220, TRIO221 - blocking sync call in async function, using subprocess or os.

--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ pip install flake8-trio
 - **TRIO115**: Replace `trio.sleep(0)` with the more suggestive `trio.lowlevel.checkpoint()`.
 - **TRIO116**: `trio.sleep()` with >24 hour interval should usually be`trio.sleep_forever()`.
 - **TRIO200**: User-configured error for blocking sync calls in async functions. Does nothing by default, see [`trio200-blocking-calls`](#trio200-blocking-calls) for how to configure it.
-- **TRIO210**: Sync HTTP call {} in async function, use `httpx.AsyncClient`.
-- **TRIO211**: Likely sync HTTP call {} in async function, use `httpx.AsyncClient`. Looks for `urllib3` method calls on pool objects, but only matching on the method signature and not the object.
-- **TRIO220**: Sync call {} in async function, use `await nursery.start(trio.run_process, ...)`.
-- **TRIO221**: Sync call {} in async function, use `await trio.run_process(...)`.
-
+- **TRIO210**: Sync HTTP call in async function, use `httpx.AsyncClient`.
+- **TRIO211**: Likely sync HTTP call in async function, use `httpx.AsyncClient`. Looks for `urllib3` method calls on pool objects, but only matching on the method signature and not the object.
+- **TRIO220**: Sync process call in async function, use `await nursery.start(trio.run_process, ...)`.
+- **TRIO221**: Sync process call in async function, use `await trio.run_process(...)`.
+- **TRIO230**: Sync IO call in async function, use `trio.open_file(...)`."
+- **TRIO231**: Sync IO call in async function, use `trio.wrap_file(...)`."
 
 ## Configuration
 [You can configure `flake8` with command-line options](https://flake8.pycqa.org/en/latest/user/configuration.html),

--- a/tests/trio22x.py
+++ b/tests/trio22x.py
@@ -16,6 +16,8 @@ async def foo():
     subprocess.getoutput()  # TRIO221: 4, 'subprocess.getoutput'
     subprocess.getstatusoutput()  # TRIO221: 4, 'subprocess.getstatusoutput'
 
+    await async_fun(subprocess.getoutput())  # TRIO221: 20, 'subprocess.getoutput'
+
     subprocess.anything()
     subprocess.foo()
     subprocess.bar.foo()

--- a/tests/trio23x.py
+++ b/tests/trio23x.py
@@ -1,0 +1,42 @@
+# ARG --enable-visitor-codes-regex=(TRIO230)|(TRIO231)
+import io
+import os
+
+import trio
+
+
+async def foo():
+    open("")  # TRIO230: 4, 'open'
+    io.open_code("")  # TRIO230: 4, 'io.open_code'
+    os.fdopen(0)  # TRIO231: 4, 'os.fdopen'
+
+    # sync call is awaited, so it can't be sync
+    await open("")
+
+    # wrapped calls are always okay
+    await trio.wrap_file(open(""))
+    await trio.wrap_file(os.fdopen(0))
+
+    # with uses the same code & logic
+    with os.fdopen(0):  # TRIO231: 9, 'os.fdopen'
+        ...
+    with open(""):  # TRIO230: 9, 'open'
+        ...
+    with open("") as f:  # TRIO230: 9, 'open'
+        ...
+    with foo(), open(""):  # TRIO230: 16, 'open'
+        ...
+    async with open(""):  # TRIO230: 15, 'open'
+        ...
+    async with trio.wrap_file(open("")):
+        ...
+
+    # test io.open
+    # pyupgrade removes the unnecessary `io.`
+    # https://github.com/asottile/pyupgrade#open-alias
+    # and afaict neither respects fmt:off nor #noqa - so I don't know how to test it
+    open("")  # TRIO230: 4, 'open'
+
+
+def foo_sync():
+    open("")


### PR DESCRIPTION
First bullet point of #58 
> Use `trio.open_file()` instead of `open()`, `io.open`, `io.open_code`, or `os.fdopen` in async functions

Although I guessed that `os.fdopen` should be wrapped in `trio.wrap_file` as per the intro

I have *no* idea how to stop shed/pyupgrade from reformatting `io.open` into `open`, tried both `#fmt: off` and `#noqa`.