### PR TITLE
Add TRIO232: blocking sync call on file objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 *[CalVer, YY.month.patch](https://calver.org/)*
+## Future
+- Add TRIO232: blocking sync call on file object.
 
 ## 23.1.4
 - TRIO114 no longer triggers on posonly args named "task_status"

--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ pip install flake8-trio
 - **TRIO211**: Likely sync HTTP call in async function, use `httpx.AsyncClient`. Looks for `urllib3` method calls on pool objects, but only matching on the method signature and not the object.
 - **TRIO220**: Sync process call in async function, use `await nursery.start(trio.run_process, ...)`.
 - **TRIO221**: Sync process call in async function, use `await trio.run_process(...)`.
-- **TRIO230**: Sync IO call in async function, use `trio.open_file(...)`."
-- **TRIO231**: Sync IO call in async function, use `trio.wrap_file(...)`."
+- **TRIO230**: Sync IO call in async function, use `trio.open_file(...)`.
+- **TRIO231**: Sync IO call in async function, use `trio.wrap_file(...)`.
+- **TRIO232**: Blocking sync call on file object, wrap the file object in `trio.wrap_file()` to get an async file object.
 - **TRIO240**: Avoid using `os.path` in async functions, prefer using `trio.Path` objects.
 
 

--- a/tests/eval_files/trio232.py
+++ b/tests/eval_files/trio232.py
@@ -1,0 +1,135 @@
+import io
+from io import BufferedRandom, BufferedReader, BufferedWriter, TextIOWrapper
+from typing import Any, Optional
+
+blah: Any = None
+
+
+async def file_text(f: io.TextIOWrapper):
+    f.read()  # TRIO232: 4, 'read', 'f'
+
+
+async def file_binary_read(f: io.BufferedReader):
+    f.read()  # TRIO232: 4, 'read', 'f'
+
+
+async def file_binary_write(f: io.BufferedWriter):
+    f.read()  # TRIO232: 4, 'read', 'f'
+
+
+async def file_binary_readwrite(f: io.BufferedRandom):
+    f.read()  # TRIO232: 4, 'read', 'f'
+
+
+async def file_text_(f: TextIOWrapper):
+    f.read()  # TRIO232: 4, 'read', 'f'
+
+
+async def file_binary_read_(f: BufferedReader):
+    f.read()  # TRIO232: 4, 'read', 'f'
+
+
+async def file_binary_write_(f: BufferedWriter):
+    f.read()  # TRIO232: 4, 'read', 'f'
+
+
+async def file_binary_readwrite_(f: BufferedRandom):
+    f.read()  # TRIO232: 4, 'read', 'f'
+
+
+async def file_text_3(f: TextIOWrapper = blah):
+    f.read()  # TRIO232: 4, 'read', 'f'
+
+
+async def file_text_4(f: TextIOWrapper | None):
+    if f:
+        f.read()  # TRIO232: 8, 'read', 'f'
+
+
+async def file_text_5(f: TextIOWrapper | None = None):
+    if f:
+        f.read()  # TRIO232: 8, 'read', 'f'
+
+
+async def file_text_6(f: Optional[TextIOWrapper] = None):
+    if f:
+        f.read()  # TRIO232: 8, 'read', 'f'
+
+
+async def file_text_7(f: TextIOWrapper = blah, /):
+    f.read()  # TRIO232: 4, 'read', 'f'
+
+
+async def file_text_8(*, f: TextIOWrapper = blah):
+    f.read()  # TRIO232: 4, 'read', 'f'
+
+
+async def file_text_9(lf: list[TextIOWrapper]):
+    for f in lf:
+        f.read()  # not handled
+
+
+async def open_file_1():
+    with open(""):
+        ...
+
+
+async def open_file_2():
+    with open("") as f:
+        print(f)
+
+
+async def open_file_3():
+    with open("") as f:
+        f.read()  # TRIO232: 8, 'read', 'f'
+
+
+async def open_file_4():
+    f = open("")
+
+
+async def open_file_5():
+    f = open("")
+    f.read()  # TRIO232: 4, 'read', 'f'
+
+
+async def open_file_6():
+    ff = open("")
+    f = ff
+    f.read()  # TRIO232: 4, 'read', 'f'
+    ff.read()  # TRIO232: 4, 'read', 'ff'
+
+
+async def noerror():
+    with blah("") as f:
+        f.read()
+
+
+def sync_fun(f: TextIOWrapper):
+    async def async_fun():
+        f.read()  # TRIO232: 8, 'read', 'f'
+
+
+def sync_fun_2():
+    f = open("")
+
+    async def async_fun():
+        f.read()  # TRIO232: 8, 'read', 'f'
+
+
+async def async_wrapper(f: TextIOWrapper):
+    def inside(f: int):
+        f.read()
+
+        async def inception():
+            f.read()
+
+        f.read()
+
+    f.read()  # TRIO232: 4, 'read', 'f'
+    lambda f: f.read()
+    f.read()  # TRIO232: 4, 'read', 'f'
+
+    # known false positive, but will be complained about by type checkers
+    f = None
+    f.read()  # TRIO232: 4, 'read', 'f'


### PR DESCRIPTION
A first draft at tracking types for file/path/httpx/etc and warning on sync calls. Except this one just does it for `open()` and the varios `io.*` types it can return as a start.
This and others that build on top of it should finish off #58 

Branched from on top of #103 - but you can just view the latest commit to see the contents of this one.

* The logic for tracking variables and their type will be moved to a superclass that different error_classes can inherit from (or possibly just implemented in `Flake8TrioVisitor`.
  * Child classes will probably be able to register calls and their return type so the superclass can use that. (so something like `super().register('open', 'io.TextIOWrapper')` in the `__init__`
  * code can then maybe be reused for the error classes tracking nurseries
* I don't think anybody in their right mind is going to send around `io.TextIOWrapper` objects to functions, but that's going to be much more common with Path and httpx objects, so I implemented it for this as well just to show the logic.
* Unless reimplemented as a plugin an top of a type checker this will ofc never be perfect, but handling `Optional[Path]` and `Path|None` will be done. `list[Path]` and similar cases can be done if it makes sense but I don't think will be common of any of the types we care about.
* I thiiink scope rules are handled correctly at the moment, but if that turns out to be tricky it can probably be dropped without worry.
* Code in general isn't super clean and will be rewritten, so don't bother with nitpicking much/at all