### PR TITLE
TRIO900 now only checks for asynccontextmanager, ignoring flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 *[CalVer, YY.month.patch](https://calver.org/)*
 
+## 23.1.4
+- TRIO900 now only checks `@asynccontextmanager`, not other decorators passed with --no-checkpoint-warning-decorators.
+
 ## 23.1.3
 - Add TRIO240: usage of `os.path` in async function.
 - Add TRIO900: ban async generators not decorated with known safe decorator

--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ pip install flake8-trio
 
 
 ### Warnings disabled by default
-- **TRIO900**: Async generator without known-safe decorator (@asynccontextmanager, or what's specified by `--no-checkpoint-warning-decorators`) not allowed."
+- **TRIO900**: Async generator without `@asynccontextmanager` not allowed.
 
 ## Configuration
 [You can configure `flake8` with command-line options](https://flake8.pycqa.org/en/latest/user/configuration.html),
 but we prefer using a config file. The file needs to start with a section marker `[flake8]` and the following options are then parsed using flake8's config parser, and can be used just like any other flake8 options.
 
 ### `no-checkpoint-warning-decorators`
-Specify a list of decorators to disable checkpointing checks for, turning off TRIO107, TRIO108 and TRIO900 warnings for functions decorated with any decorator matching any in the list. Matching is done with [fnmatch](https://docs.python.org/3/library/fnmatch.html). Defaults to disabling for `asynccontextmanager`.
+Specify a list of decorators to disable checkpointing checks for, turning off TRIO107 and TRIO108 warnings for functions decorated with any decorator matching any in the list. Matching is done with [fnmatch](https://docs.python.org/3/library/fnmatch.html). Defaults to disabling for `asynccontextmanager`.
 
 Decorators-to-match must be identifiers or dotted names only (not PEP-614 expressions), and will match against the name only - e.g. `foo.bar` matches `foo.bar`, `foo.bar()`, and `foo.bar(args, here)`, etc.
 

--- a/flake8_trio/__init__.py
+++ b/flake8_trio/__init__.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 
 # CalVer: YY.month.patch, e.g. first release of July 2022 == "22.7.1"
-__version__ = "23.1.3"
+__version__ = "23.1.4"
 
 
 class Plugin:

--- a/flake8_trio/visitors/visitors.py
+++ b/flake8_trio/visitors/visitors.py
@@ -10,7 +10,6 @@ from .helpers import (
     cancel_scope_names,
     disabled_by_default,
     error_class,
-    fnmatch_qualified_name,
     get_matching_call,
     has_decorator,
 )
@@ -390,7 +389,7 @@ class Visitor116(Flake8TrioVisitor):
 @disabled_by_default
 class Visitor900(Flake8TrioVisitor):
     error_codes = {
-        "TRIO900": ("Async generator without known-safe decorator not allowed.")
+        "TRIO900": ("Async generator without `@asynccontextmanager` not allowed.")
     }
 
     def __init__(self, *args: Any, **kwargs: Any):
@@ -401,8 +400,8 @@ class Visitor900(Flake8TrioVisitor):
         self, node: ast.AsyncFunctionDef | ast.FunctionDef | ast.Lambda
     ):
         self.save_state(node, "unsafe_function")
-        if isinstance(node, ast.AsyncFunctionDef) and not fnmatch_qualified_name(
-            node.decorator_list, *self.options.no_checkpoint_warning_decorators
+        if isinstance(node, ast.AsyncFunctionDef) and not any(
+            _get_identifier(d) == "asynccontextmanager" for d in node.decorator_list
         ):
             self.unsafe_function = node
 

--- a/tests/eval_files/trio900.py
+++ b/tests/eval_files/trio900.py
@@ -23,6 +23,7 @@ def foo4():
     yield
 
 
+# no-checkpoint-warning-decorator now ignored
 @other_context_manager
-async def foo5():
+async def foo5():  # TRIO900: 0
     yield


### PR DESCRIPTION
Split this out cause I wasn't sure if it was going to be a bigger PR - but ended up being quite manageable.