### PR TITLE
Fix TRIO103 false alarm on excepts after a previous except has caught Cancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Future
 - Add TRIO232: blocking sync call on file object.
 
+## Future
+- TRIO103 and TRIO104 no longer triggers when `trio.Cancelled` has been handled in previous except handlers.
+
 ## 23.1.4
 - TRIO114 no longer triggers on posonly args named "task_status"
 - TRIO116 will now match on any attribute parameter named `.inf`, not just `math.inf`.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pip install flake8-trio
 - **TRIO101**: `yield` inside a nursery or cancel scope is only safe when implementing a context manager - otherwise, it breaks exception handling.
 - **TRIO102**: it's unsafe to await inside `finally:` or `except BaseException/trio.Cancelled` unless you use a shielded
   cancel scope with a timeout.
-- **TRIO103**: `except BaseException` and `except trio.Cancelled` with a code path that doesn't re-raise.
+- **TRIO103**: `except BaseException`, `except trio.Cancelled` or a bare `except:` with a code path that doesn't re-raise. If you don't want to re-raise `BaseException`, add a separate handler for `trio.Cancelled` before.
 - **TRIO104**: `Cancelled` and `BaseException` must be re-raised - when a user tries to `return` or `raise` a different exception.
 - **TRIO105**: Calling a trio async function without immediately `await`ing it.
 - **TRIO106**: trio must be imported with `import trio` for the linter to work.

--- a/tests/eval_files/trio103_no_104.py
+++ b/tests/eval_files/trio103_no_104.py
@@ -1,169 +1,21 @@
+# ARG --enable-visitor-codes-regex=TRIO103
 # check that partly disabling a visitor works
 from typing import Any
-
-import trio
 
 
 def foo() -> Any:
     ...
 
 
-try:
-    pass
-except (SyntaxError, ValueError, BaseException):
-    raise
-except (SyntaxError, ValueError, trio.Cancelled) as p:  # error: 33, "trio.Cancelled"
-    pass
-except (SyntaxError, ValueError):
-    raise
-except trio.Cancelled as e:
-    raise e
-except trio.Cancelled as e:
-    raise  # acceptable - see https://peps.python.org/pep-0678/#example-usage
-except trio.Cancelled:  # error: 7, "trio.Cancelled"
-    pass
-
-# if
-except BaseException as e:  # error: 7, "BaseException"
-    if True:
-        raise e
-    elif True:
-        pass
-    else:
-        raise e
-except BaseException:  # error: 7, "BaseException"
-    if True:
-        raise
-except BaseException:  # safe
-    if True:
-        raise
-    elif True:
-        raise
-    else:
-        raise
-
-# loops
-# raises inside the body are never guaranteed to run and are ignored
-except trio.Cancelled:  # error: 7, "trio.Cancelled"
-    while foo():
-        raise
-
-# raise inside else are guaranteed to run, unless there's a break
-except trio.Cancelled:
-    while ...:
-        ...
-    else:
-        raise
-except trio.Cancelled:
-    for _ in "":
-        ...
-    else:
-        raise
-except BaseException:  # error: 7, "BaseException"
-    while ...:
-        if ...:
-            break
-        raise
-    else:
-        raise
-except BaseException:  # error: 7, "BaseException"
-    for _ in "":
-        if ...:
-            break
-        raise
-    else:
-        raise
-# ensure we don't ignore previous guaranteed raise (although that's unreachable code)
-except BaseException:
-    raise
-    for _ in "":
-        if ...:
-            break
-        raise
-    else:
-        raise
-
 # nested try
 # in theory safe if the try, and all excepts raises - and there's a bare except.
 # But is a very weird pattern that we don't handle.
-except BaseException as e:  # error: 7, "BaseException"
+try:
+    ...
+except trio.Cancelled as e:  # error: 7, "trio.Cancelled", ""
     try:
         raise e
     except ValueError:
         raise e
     except:
         raise e  # disabled TRIO104 error
-except BaseException:  # safe
-    try:
-        pass
-    finally:
-        raise
-# check that nested non-critical exceptions are ignored
-except BaseException:
-    try:
-        pass
-    except ValueError:
-        pass  # safe
-    raise
-# check that name isn't lost
-except trio.Cancelled as e:
-    try:
-        pass
-    except BaseException as f:
-        raise f
-    raise e
-# don't bypass raise by raising from nested except
-except trio.Cancelled as e:
-    try:
-        pass
-    except ValueError as g:
-        raise g  # disabled TRIO104 error
-    except BaseException as h:
-        raise h  # error? currently treated as safe
-    raise e
-# bare except, equivalent to `except baseException`
-except:  # error: 0, "bare except"
-    pass
-try:
-    pass
-except:
-    raise
-
-# point to correct exception in multi-line handlers
-my_super_mega_long_exception_so_it_gets_split = SyntaxError
-try:
-    pass
-except (
-    my_super_mega_long_exception_so_it_gets_split,
-    SyntaxError,
-    BaseException,  # error: 4, "BaseException"
-    ValueError,
-    trio.Cancelled,  # no complaint on this line
-):
-    pass
-
-# loop over non-empty static collection
-except BaseException as e:
-    for i in [1, 2, 3]:
-        raise
-except BaseException:  # error: 7, "BaseException"
-    for i in [1, 2, 3]:
-        ...
-except BaseException:  # error: 7, "BaseException"
-    for i in [1, 2, 3]:
-        if ...:
-            continue
-        raise
-except BaseException:
-    while True:
-        raise
-except BaseException:  # error: 7, "BaseException"
-    while True:
-        if ...:
-            break
-        raise
-except BaseException:
-    while True:
-        if ...:
-            continue
-        raise


### PR DESCRIPTION
Fixes #106 

Also fixes several other cases not mentioned in the issue, and does the same for TRIO104.

Took me a minute to understand the existing 103/104 implementation and where to inject the logic for this, but ultimately a pretty simple addition.

It broke, like, *all* of the 103/104 tests though since they didn't bother having separate `try`s for the excepts, so went ham on adding those. But I didn't bother fixing `trio103_no_104.py` and cut that down to the minimal tests needed to check what that one actually checks. (that 103 is enabled, and not 104, when only one of them is selected with the regex).
But at the end of `trio103.py` and `trio104.py` are the new test cases added