### PR TITLE
add TRIO117, error on any reference to multierror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ## Future
 - TRIO103 and TRIO104 no longer triggers when `trio.Cancelled` has been handled in previous except handlers.
-- Add TRIO117: Reference to `[NonBase]MultiError`
+- Add TRIO117: Reference to deprecated `trio.[NonBase]MultiError`; use `[Base]ExceptionGroup` instead.
 
 ## 23.1.4
 - TRIO114 no longer triggers on posonly args named "task_status"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Future
 - TRIO103 and TRIO104 no longer triggers when `trio.Cancelled` has been handled in previous except handlers.
+- Add TRIO117: Reference to `[NonBase]MultiError`
 
 ## 23.1.4
 - TRIO114 no longer triggers on posonly args named "task_status"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ pip install flake8-trio
 - **TRIO114**: Startable function (i.e. has a `task_status` keyword parameter) not in `--startable-in-context-manager` parameter list, please add it so TRIO113 can catch errors when using it.
 - **TRIO115**: Replace `trio.sleep(0)` with the more suggestive `trio.lowlevel.checkpoint()`.
 - **TRIO116**: `trio.sleep()` with >24 hour interval should usually be`trio.sleep_forever()`.
+- **TRIO117**: Don't raise or catch `trio.[NonBase]MultiError`, prefer `[exceptiongroup.]BaseExceptionGroup`. Even if Trio still raises `MultiError` for legacy code, it can be caught with `BaseExceptionGroup` so it's fully redundant.
 - **TRIO200**: User-configured error for blocking sync calls in async functions. Does nothing by default, see [`trio200-blocking-calls`](#trio200-blocking-calls) for how to configure it.
 - **TRIO210**: Sync HTTP call in async function, use `httpx.AsyncClient`.
 - **TRIO211**: Likely sync HTTP call in async function, use `httpx.AsyncClient`. Looks for `urllib3` method calls on pool objects, but only matching on the method signature and not the object.

--- a/flake8_trio/visitors/visitors.py
+++ b/flake8_trio/visitors/visitors.py
@@ -380,6 +380,21 @@ class Visitor116(Flake8TrioVisitor):
 
 
 @error_class
+class Visitor117(Flake8TrioVisitor):
+    error_codes = {
+        "TRIO117": ("Reference to {}, prefer [exceptiongroup.]BaseExceptionGroup"),
+    }
+
+    def visit_Name(self, node: ast.Name):
+        if node.id in ("MultiError", "NonBaseMultiError"):
+            self.error(node, node.id)
+
+    def visit_Attribute(self, node: ast.Attribute):
+        if (n := ast.unparse(node)) in ("trio.MultiError", "trio.NonBaseMultiError"):
+            self.error(node, n)
+
+
+@error_class
 @disabled_by_default
 class Visitor900(Flake8TrioVisitor):
     error_codes = {

--- a/tests/eval_files/trio117.py
+++ b/tests/eval_files/trio117.py
@@ -1,0 +1,43 @@
+# Conventional usage
+try:
+    raise MultiError  # TRIO117: 10, "MultiError"
+    raise NonBaseMultiError  # TRIO117: 10, "NonBaseMultiError"
+    raise trio.MultiError  # TRIO117: 10, "trio.MultiError"
+    raise trio.NonBaseMultiError  # TRIO117: 10, "trio.NonBaseMultiError"
+except MultiError:  # TRIO117: 7, "MultiError"
+    ...
+except NonBaseMultiError:  # TRIO117: 7, "NonBaseMultiError"
+    ...
+except trio.MultiError:  # TRIO117: 7, "trio.MultiError"
+    ...
+except trio.NonBaseMultiError:  # TRIO117: 7, "trio.NonBaseMultiError"
+    ...
+
+# Any other mention of it
+MultiError  # TRIO117: 0, "MultiError"
+NonBaseMultiError  # TRIO117: 0, "NonBaseMultiError"
+trio.MultiError  # TRIO117: 0, "trio.MultiError"
+trio.NonBaseMultiError  # TRIO117: 0, "trio.NonBaseMultiError"
+
+MultiError.foo  # TRIO117: 0, "MultiError"
+trio.MultiError.foo  # TRIO117: 0, "trio.MultiError"
+
+MultiError()  # TRIO117: 0, "MultiError"
+
+
+def bar(x: MultiError):  # TRIO117: 11, "MultiError"
+    ...
+
+
+# Known false alarm
+MultiError: int  # TRIO117: 0, "MultiError"
+
+# args are not ast.Name's, so this one (surprisingly!) isn't a false positive
+# (though any use of the variable will be)
+def foo(MultiError: int):
+    ...
+
+
+# only triggers on *trio*.MultiError
+anything.MultiError
+blah.MultiError.bee

--- a/tests/test_flake8_trio.py
+++ b/tests/test_flake8_trio.py
@@ -165,6 +165,7 @@ error_codes_ignored_when_checking_transformed_sync_code = {
     "TRIO112",
     "TRIO115",
     "TRIO116",
+    "TRIO117",
 }
 
 


### PR DESCRIPTION
Fixes #105 
I made some assumptions when writing the README message, and the error message could maybe be more informative.
Otherwise a very simple and straightforward check. I could restrict it to raise/catch/methods if this is too liberal, but simplest was to just trigger on any name/attribute and not care about context.