### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@
 - TRIO103 now correctly handles raises in loops, i.e. `raise` in else is guaranteed to run unless there's a `break` in the body.
 
 ## 22.8.5
-- Add TRIO111: Variable, from context manager opened inside nursery, passed to `start[_soon]` might be invalidly accesed while in use, due to context manager closing before the nursery. This is usually a bug, and nurseries should generally be the inner-most context manager.
+- Add TRIO111: Variable, from context manager opened inside nursery, passed to `start[_soon]` might be invalidly accessed while in use, due to context manager closing before the nursery. This is usually a bug, and nurseries should generally be the inner-most context manager.
 - Add TRIO112: this single-task nursery could be replaced by awaiting the function call directly.
 
 ## 22.8.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ You can instead of `error` specify the error code.
 
 ### `# ARG`
 With `# ARG` lines you can also specify command-line arguments that should be passed to the plugin when parsing a file. Can be specified multiple times for several different arguments.  
-Generated tests will by default `--select` the error code of the file, which will enable any visitors that can generate that code (and if those visitors can raise other codes they might be raised too). This can be overriden by adding an `# ARG --select=...` line.
+Generated tests will by default `--select` the error code of the file, which will enable any visitors that can generate that code (and if those visitors can raise other codes they might be raised too). This can be overridden by adding an `# ARG --select=...` line.
 
 ## Running pytest outside tox
 If you don't want to bother with tox to quickly test stuff, you'll need to install the following dependencies:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pip install flake8-trio
   Checkpoints are `await`, `async for`, and `async with` (on one of enter/exit).
 - **TRIO109**: Async function definition with a `timeout` parameter - use `trio.[fail/move_on]_[after/at]` instead
 - **TRIO110**: `while <condition>: await trio.sleep()` should be replaced by a `trio.Event`.
-- **TRIO111**: Variable, from context manager opened inside nursery, passed to `start[_soon]` might be invalidly accesed while in use, due to context manager closing before the nursery. This is usually a bug, and nurseries should generally be the inner-most context manager.
+- **TRIO111**: Variable, from context manager opened inside nursery, passed to `start[_soon]` might be invalidly accessed while in use, due to context manager closing before the nursery. This is usually a bug, and nurseries should generally be the inner-most context manager.
 - **TRIO112**: nursery body with only a call to `nursery.start[_soon]` and not passing itself as a parameter can be replaced with a regular function call.
 - **TRIO113**: using `nursery.start_soon` in `__aenter__` doesn't wait for the task to begin. Consider replacing with `nursery.start`.
 - **TRIO114**: Startable function (i.e. has a `task_status` keyword parameter) not in `--startable-in-context-manager` parameter list, please add it so TRIO113 can catch errors when using it.
@@ -97,7 +97,7 @@ trio200-blocking-calls =
   dangerous_module.* -> corresponding function in safe_module,
   *.dangerous_call -> .safe_call()
 ```
-Specified patterns must not have parantheses, and will only match when the pattern is the name of a call, so given the above configuration
+Specified patterns must not have parentheses, and will only match when the pattern is the name of a call, so given the above configuration
 ```python
 async def my_function():
     my_blocking_call()  # this would raise an error

--- a/flake8_trio/visitors/visitor102.py
+++ b/flake8_trio/visitors/visitor102.py
@@ -60,7 +60,7 @@ class Visitor102(Flake8TrioVisitor):
     def visit_With(self, node: ast.With | ast.AsyncWith):
         self.save_state(node, "_trio_context_managers", copy=True)
 
-        # Check for a `with trio.<scope_creater>`
+        # Check for a `with trio.<scope_creator>`
         for item in node.items:
             call = get_matching_call(
                 item.context_expr, "open_nursery", *cancel_scope_names

--- a/flake8_trio/visitors/visitor107_108.py
+++ b/flake8_trio/visitors/visitor107_108.py
@@ -232,7 +232,7 @@ class Visitor107_108(Flake8TrioVisitor):
     # inline if
     visit_IfExp = visit_If
 
-    # Check for yields w/o checkpoint inbetween due to entering loop body the first time,
+    # Check for yields w/o checkpoint in between due to entering loop body the first time,
     # after completing all of loop body, and after any continues.
     # yield in else have same requirement
     # state after the loop same as above, and in addition the state at any break

--- a/tests/eval_files/trio109.py
+++ b/tests/eval_files/trio109.py
@@ -12,7 +12,7 @@ async def foo_1(timeout):  # error: 16
     ...
 
 
-# arg in args wih default & annotation
+# arg in args with default & annotation
 async def foo_2(timeout: int = 3):  # error: 16
     ...
 

--- a/tests/eval_files/trio111.py
+++ b/tests/eval_files/trio111.py
@@ -230,7 +230,7 @@ with trio.open_nursery() as nursery:
         def myfun(nursery, bar):
             nursery.start(bar)
 
-# nursery overriden by non-expression context manager
+# nursery overridden by non-expression context manager
 b = trio.open()
 with trio.open_nursery() as nursery:
     with b as nursery:


### PR DESCRIPTION
Found via `codespell -S .mypy_cache -L aline`