### PR TITLE
add codespell to pre-commit, add exception for spawnve, rename aline variable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,13 @@ repos:
           - pytest
           - flake8
 
+-   repo: https://github.com/codespell-project/codespell
+    rev: v2.2.2
+    hooks:
+    - id: codespell
+      additional_dependencies:
+          - tomli
+
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [tool.pyright]
 strict = ["*.py", "tests/test_flake8_trio.py", "tests/conftest.py"]
 exclude = ["tests/eval_files/*", "**/node_modules", "**/__pycache__", "**/.*"]
+
+[tool.codespell]
+ignore-words-list = 'spawnve'

--- a/tests/test_changelog_and_version.py
+++ b/tests/test_changelog_and_version.py
@@ -31,8 +31,8 @@ def get_releases() -> Iterable[Version]:
     valid_pattern = re.compile(r"^## (\d\d\.\d?\d\.\d?\d)$")
     with open(root_path / "CHANGELOG.md", encoding="utf-8") as f:
         lines = f.readlines()
-    for aline in lines:
-        version_match = valid_pattern.match(aline)
+    for line in lines:
+        version_match = valid_pattern.match(line)
         if version_match:
             yield Version.from_string(version_match.group(1))
 


### PR DESCRIPTION
Makes it so #113 won't happen again