### PR TITLE
Add TRIO222, extend TRIO221, flake8-async redundant

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ ci:
 
 repos:
 -   repo: https://github.com/Zac-HD/shed
-    rev: 0.10.8
+    rev: 0.10.9
     hooks:
     -   id: shed
         args: ['--py39-plus']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Future
 - Add TRIO232: blocking sync call on file object.
 - Add TRIO212: blocking sync call on httpx.Client object.
+- Add TRIO222: os.wait*
+- TRIO221 now also looks for os.posix_spawn[p]
 
 ## Future
 - TRIO103 and TRIO104 no longer triggers when `trio.Cancelled` has been handled in previous except handlers.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ pip install flake8-trio
 - **TRIO212**: Blocking sync HTTP call on httpx object, use httpx.AsyncClient.
 - **TRIO220**: Sync process call in async function, use `await nursery.start(trio.run_process, ...)`.
 - **TRIO221**: Sync process call in async function, use `await trio.run_process(...)`.
-- **TRIO222**: Sync call in async function, use a nursery or other methods for intra-process communications.
+- **TRIO222**: Sync `os.*` call in async function, wrap in `await trio.to_thread.run_sync()`.
 - **TRIO230**: Sync IO call in async function, use `trio.open_file(...)`.
 - **TRIO231**: Sync IO call in async function, use `trio.wrap_file(...)`.
 - **TRIO232**: Blocking sync call on file object, wrap the file object in `trio.wrap_file()` to get an async file object.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ a misunderstanding.
 
 It may well be too noisy for anyone with different opinions, that's OK.
 
-Pairs well with flake8-async and flake8-bugbear.
+Pairs well with flake8-bugbear.
 
 ## Installation
 
@@ -46,6 +46,7 @@ pip install flake8-trio
 - **TRIO212**: Blocking sync HTTP call on httpx object, use httpx.AsyncClient.
 - **TRIO220**: Sync process call in async function, use `await nursery.start(trio.run_process, ...)`.
 - **TRIO221**: Sync process call in async function, use `await trio.run_process(...)`.
+- **TRIO222**: Sync call in async function, use a nursery or other methods for intra-process communications.
 - **TRIO230**: Sync IO call in async function, use `trio.open_file(...)`.
 - **TRIO231**: Sync IO call in async function, use `trio.wrap_file(...)`.
 - **TRIO232**: Blocking sync call on file object, wrap the file object in `trio.wrap_file()` to get an async file object.

--- a/flake8_trio/visitors/visitor2xx.py
+++ b/flake8_trio/visitors/visitor2xx.py
@@ -249,10 +249,7 @@ class Visitor22X(Visitor200):
             "`await nursery.start(trio.run_process, ...)`"
         ),
         "TRIO221": "Sync call {} in async function, use `await trio.run_process(...)`",
-        "TRIO222": (
-            "Sync call {} in async function, use a nursery or other methods"
-            " for intra-process communications."
-        ),
+        "TRIO222": "Sync call {} in async function, wrap in `trio.to_thread.run_sync()`",
     }
 
     def visit_blocking_call(self, node: ast.Call):

--- a/tests/eval_files/trio103.py
+++ b/tests/eval_files/trio103.py
@@ -9,6 +9,9 @@ def foo() -> Any:
     ...
 
 
+# fmt: off
+# TODO: Black 23.1.0 moves the long comments around a bit.
+
 try:
     ...
 except (SyntaxError, ValueError, BaseException):

--- a/tests/eval_files/trio104.py
+++ b/tests/eval_files/trio104.py
@@ -20,6 +20,9 @@ except trio.Cancelled as e:
     raise BaseException() from e  # error: 4
 
 
+# fmt: off
+# TODO: Black 23.1.0 moves the long comments around a bit.
+
 # nested try
 # in theory safe if the try, and all excepts raises - and there's a bare except.
 # But is a very weird pattern that we don't handle.

--- a/tests/eval_files/trio107.py
+++ b/tests/eval_files/trio107.py
@@ -12,6 +12,7 @@ def __() -> Any:
 
 # ARG --enable-visitor-codes-regex=(TRIO107)|(TRIO108)
 
+
 # function whose body solely consists of pass, ellipsis, or string constants is safe
 async def foo_empty_1():
     ...

--- a/tests/eval_files/trio108.py
+++ b/tests/eval_files/trio108.py
@@ -117,6 +117,7 @@ async def foo_for_1():  # error: 0, "exit", Statement("function definition", lin
 
 # while
 
+
 # safe if checkpoint in else
 async def foo_while_1():  # error: 0, "exit", Statement("yield", lineno+5)
     while foo():
@@ -603,6 +604,7 @@ async def foo_boolops_3():  # error: 0, "exit", Stmt("yield", line+1) # error: 0
             and (yield))  # error: 17, "yield", Stmt("yield", line-1)
     )
 # fmt: on
+
 
 # loop over non-empty static collection
 async def foo_loop_static():

--- a/tests/eval_files/trio112.py
+++ b/tests/eval_files/trio112.py
@@ -76,6 +76,7 @@ with trio.open_nursery() as n:
 with trio.open_nursery() as n:
     n.start_soon(lambda n: n + 1)
 
+
 # body isn't a call to n.start
 async def foo_1():
     with trio.open_nursery(...) as n:

--- a/tests/eval_files/trio117.py
+++ b/tests/eval_files/trio117.py
@@ -32,6 +32,7 @@ def bar(x: MultiError):  # TRIO117: 11, "MultiError"
 # Known false alarm
 MultiError: int  # TRIO117: 0, "MultiError"
 
+
 # args are not ast.Name's, so this one (surprisingly!) isn't a false positive
 # (though any use of the variable will be)
 def foo(MultiError: int):

--- a/tests/eval_files/trio200.py
+++ b/tests/eval_files/trio200.py
@@ -3,6 +3,7 @@
 # Cannot test newlines, since argparse splits on those if passed on the CLI
 # ARG --trio200-blocking-calls=bar -> BAR, bee-> SHOULD_NOT_BE_PRINTED,bonnet ->SHOULD_NOT_BE_PRINTED,bee.bonnet->BEEBONNET,*.postwild->POSTWILD,prewild.*->PREWILD,*.*.*->TRIPLEDOT,
 
+
 # don't error in sync function
 def foo():
     bar()

--- a/tests/eval_files/trio22x.py
+++ b/tests/eval_files/trio22x.py
@@ -1,4 +1,4 @@
-# ARG --enable-visitor-codes-regex=(TRIO220|TRIO221)
+# ARG --enable-visitor-codes-regex=(TRIO220|TRIO221|TRIO222)
 
 
 async def foo():
@@ -23,8 +23,12 @@ async def foo():
     subprocess.bar.foo()
     subprocess()
 
+    os.posix_spawn()  # TRIO221: 4, 'os.posix_spawn'
+    os.posix_spawnp()  # TRIO221: 4, 'os.posix_spawnp'
+
     os.spawn()
     os.spawn
+    os.spawnllll()
 
     os.spawnl()  # TRIO221: 4,   'os.spawnl'
     os.spawnle()  # TRIO221: 4,  'os.spawnle'
@@ -53,3 +57,13 @@ async def foo():
     os.spawnl(0)  # TRIO220: 4,   'os.spawnl'
     os.spawnl(1)  # TRIO220: 4,   'os.spawnl'
     os.spawnl(foo())  # TRIO220: 4,   'os.spawnl'
+
+    # TRIO222
+    os.wait()  # TRIO222: 4, 'os.wait'
+    os.wait3()  # TRIO222: 4, 'os.wait3'
+    os.wait4()  # TRIO222: 4, 'os.wait4'
+    os.waitid()  # TRIO222: 4, 'os.waitid'
+    os.waitpid()  # TRIO222: 4, 'os.waitpid'
+
+    os.waitpi()
+    os.waiti()

--- a/tests/eval_files/trio232.py
+++ b/tests/eval_files/trio232.py
@@ -136,6 +136,7 @@ async def type_assign():
 f = open("")
 g: TextIOWrapper = ...
 
+
 # Test state handling on nested functions
 async def async_wrapper(f: TextIOWrapper):
     def inside(f: int):
@@ -171,6 +172,7 @@ async def overridden_type(f: TextIOWrapper):
 
 
 # ***** Known unhandled cases *****
+
 
 # It will error on non-explicit assignments
 async def implicit_overridden_type():


### PR DESCRIPTION
Since https://docs.python.org/3/library/os.html#os.posix_spawn recommends using `subprocess.run` instead I assumed it should use the same error message as it.

Feels kinda hard to give a good drop-in replacement for `os.wait*` since it may be used for so much, but made a guess - feel free to suggest something else.

Closes #58 at last! And also makes flake8-async fully redundant