### PR TITLE
Add support for the anyio library

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,12 @@ You can instead of `error` specify the error code.
 With `# ARG` lines you can also specify command-line arguments that should be passed to the plugin when parsing a file. Can be specified multiple times for several different arguments.  
 Generated tests will by default `--select` the error code of the file, which will enable any visitors that can generate that code (and if those visitors can raise other codes they might be raised too). This can be overridden by adding an `# ARG --select=...` line.
 
+### `# NOANYIO` and `# NOTRIO`
+Eval files are also evaluated where ~all instances of "trio" is replaced with "anyio" and `--anyio` is prepended to the argument list, to check for compatibility with the [anyio](https://github.com/agronholm/anyio) library - unless they are marked with `# NOANYIO`.
+If a file is marked with `# NOTRIO` it will not replace instances of "trio" with "anyio", and the file will not be run by the normal `eval_files` test generator.
+#### `# ANYIO_NO_ERROR`
+A file which is marked with this will ignore all `# error` or `# TRIO...` comments when running with anyio. Use when an error is trio-specific and replacing "trio" with "anyio" should silence all errors.
+
 ## Running pytest outside tox
 If you don't want to bother with tox to quickly test stuff, you'll need to install the following dependencies:
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # flake8-trio
 
-A highly opinionated flake8 plugin for Trio-related problems.
+A highly opinionated flake8 plugin for [Trio](https://github.com/python-trio/trio)-related problems.
 
 This can include anything from outright bugs, to pointless/dead code,
 to likely performance issues, to minor points of idiom that might signal
 a misunderstanding.
 
 It may well be too noisy for anyone with different opinions, that's OK.
+
+It also supports the [anyio](https://github.com/agronholm/anyio) library.
 
 Pairs well with flake8-bugbear.
 

--- a/flake8_trio/__init__.py
+++ b/flake8_trio/__init__.py
@@ -111,6 +111,20 @@ class Plugin:
                 "not report codes matching this regex."
             ),
         )
+        option_manager.add_option(
+            "--anyio",
+            # action=store_true + parse_from_config does seem to work here, despite
+            # https://github.com/PyCQA/flake8/issues/1770
+            action="store_true",
+            parse_from_config=True,
+            required=False,
+            default=False,
+            help=(
+                "Change the default library to be anyio instead of trio."
+                " If trio is imported it will assume both are available and print"
+                " suggestions with [anyio|trio]."
+            ),
+        )
 
     @staticmethod
     def parse_options(options: Namespace):

--- a/flake8_trio/visitors/helpers.py
+++ b/flake8_trio/visitors/helpers.py
@@ -136,15 +136,16 @@ cancel_scope_names = (
 
 
 # convenience function used in a lot of visitors
+# should probably return a named tuple
 def get_matching_call(
-    node: ast.AST, *names: str, base: str = "trio"
-) -> tuple[ast.Call, str] | None:
+    node: ast.AST, *names: str, base: Iterable[str] = ("trio", "anyio")
+) -> tuple[ast.Call, str, str] | None:
     if (
         isinstance(node, ast.Call)
         and isinstance(node.func, ast.Attribute)
         and isinstance(node.func.value, ast.Name)
-        and node.func.value.id == base
+        and node.func.value.id in base
         and node.func.attr in names
     ):
-        return node, node.func.attr
+        return node, node.func.attr, node.func.value.id
     return None

--- a/flake8_trio/visitors/visitor102.py
+++ b/flake8_trio/visitors/visitor102.py
@@ -23,7 +23,7 @@ class Visitor102(Flake8TrioVisitor):
     }
 
     class TrioScope:
-        def __init__(self, node: ast.Call, funcname: str):
+        def __init__(self, node: ast.Call, funcname: str, _):
             self.node = node
             self.funcname = funcname
             self.variable_name: str | None = None

--- a/tests/eval_files/anyio_trio.py
+++ b/tests/eval_files/anyio_trio.py
@@ -1,0 +1,9 @@
+# ARG --enable-visitor-codes-regex=(TRIO220)
+# NOTRIO
+
+# anyio eval will automatically prepend this test with `--anyio`
+import trio  # isort: skip
+
+
+async def foo():
+    subprocess.Popen()  # TRIO220: 4, 'subprocess.Popen', "[anyio|trio]"

--- a/tests/eval_files/no_library.py
+++ b/tests/eval_files/no_library.py
@@ -1,0 +1,4 @@
+# ARG --enable-visitor-codes-regex=(TRIO220)
+# NOANYIO
+async def foo():
+    subprocess.Popen()  # TRIO220: 4, 'subprocess.Popen', "trio"

--- a/tests/eval_files/trio100.py
+++ b/tests/eval_files/trio100.py
@@ -1,11 +1,11 @@
 import trio
 
-with trio.move_on_after(10):  # error: 5,"trio.move_on_after"
+with trio.move_on_after(10):  # error: 5,"trio", "move_on_after"
     pass
 
 
 async def function_name():
-    async with trio.fail_after(10):  # error: 15,"trio.fail_after"
+    async with trio.fail_after(10):  # error: 15,"trio", "fail_after"
         pass
 
     with trio.move_on_after(10):
@@ -23,7 +23,7 @@ async def function_name():
     with open("filename") as _:
         pass
 
-    with trio.fail_after(10):  # error: 9,"trio.fail_after"
+    with trio.fail_after(10):  # error: 9,"trio", "fail_after"
         pass
 
     send_channel, receive_channel = trio.open_memory_channel(0)
@@ -41,13 +41,13 @@ import trio
 async def function_name():
     with (
         open("") as _,
-        trio.fail_after(10),  # error: 8, "trio.fail_after"
+        trio.fail_after(10),  # error: 8, "trio", "fail_after"
     ):
         pass
 
     with (
-        trio.fail_after(5),  # error: 8, "trio.fail_after"
+        trio.fail_after(5),  # error: 8, "trio", "fail_after"
         open("") as _,
-        trio.move_on_after(5),  # error: 8, "trio.move_on_after"
+        trio.move_on_after(5),  # error: 8, "trio", "move_on_after"
     ):
         pass

--- a/tests/eval_files/trio102.py
+++ b/tests/eval_files/trio102.py
@@ -162,39 +162,11 @@ async def foo3():
             await foo()  # safe in theory, error: 12, Statement("try/finally", lineno-12)
 
 
-# New: except cancelled/baseexception are also critical
-async def foo4():
-    try:
-        ...
-    except ValueError:
-        await foo()  # safe
-    except trio.Cancelled:
-        await foo()  # error: 8, Statement("trio.Cancelled", lineno-1)
-    except BaseException:
-        await foo()  # error: 8, Statement("BaseException", lineno-1)
-    except:
-        await foo()  # error: 8, Statement("bare except", lineno-1)
-
-
-async def foo5():
-    try:
-        ...
-    except trio.Cancelled:
-        with trio.CancelScope(deadline=30, shield=True):
-            await foo()  # safe
-    except BaseException:
-        with trio.CancelScope(deadline=30, shield=True):
-            await foo()  # safe
-    except:
-        with trio.CancelScope(deadline=30, shield=True):
-            await foo()  # safe
-
-
 # multiple errors on same line
 # fmt: off
 async def foo6():
     try:
         ...
-    except trio.Cancelled:
-        _ = await foo(), await foo()  # error: 12, Statement("trio.Cancelled", lineno-1) # error: 25, Statement("trio.Cancelled", lineno-1)
+    except BaseException:
+        _ = await foo(), await foo()  # error: 12, Statement("BaseException", lineno-1) # error: 25, Statement("BaseException", lineno-1)
 # fmt: on

--- a/tests/eval_files/trio102_anyio.py
+++ b/tests/eval_files/trio102_anyio.py
@@ -1,0 +1,28 @@
+import anyio
+
+
+async def foo4():
+    try:
+        ...
+    except ValueError:
+        await foo()  # safe
+    except anyio.Cancelled:
+        await foo()  # not an error
+    except BaseException:
+        await foo()  # error: 8, Statement("BaseException", lineno-1)
+    except:
+        await foo()  # error: 8, Statement("bare except", lineno-1)
+
+
+async def foo5():
+    try:
+        ...
+    except anyio.Cancelled:
+        with anyio.CancelScope(deadline=30, shield=True):
+            await foo()  # safe
+    except BaseException:
+        with anyio.CancelScope(deadline=30, shield=True):
+            await foo()  # safe
+    except:
+        with anyio.CancelScope(deadline=30, shield=True):
+            await foo()  # safe

--- a/tests/eval_files/trio102_trio.py
+++ b/tests/eval_files/trio102_trio.py
@@ -1,0 +1,29 @@
+# NOANYIO
+
+
+# New: except cancelled/baseexception are also critical
+async def foo4():
+    try:
+        ...
+    except ValueError:
+        await foo()  # safe
+    except trio.Cancelled:
+        await foo()  # error: 8, Statement("trio.Cancelled", lineno-1)
+    except BaseException:
+        await foo()  # error: 8, Statement("BaseException", lineno-1)
+    except:
+        await foo()  # error: 8, Statement("bare except", lineno-1)
+
+
+async def foo5():
+    try:
+        ...
+    except trio.Cancelled:
+        with trio.CancelScope(deadline=30, shield=True):
+            await foo()  # safe
+    except BaseException:
+        with trio.CancelScope(deadline=30, shield=True):
+            await foo()  # safe
+    except:
+        with trio.CancelScope(deadline=30, shield=True):
+            await foo()  # safe

--- a/tests/eval_files/trio103.py
+++ b/tests/eval_files/trio103.py
@@ -1,4 +1,5 @@
 # ARG --enable-visitor-codes-regex=(TRIO103)|(TRIO104)
+# NOANYIO - not implemented
 
 from typing import Any
 

--- a/tests/eval_files/trio103_no_104.py
+++ b/tests/eval_files/trio103_no_104.py
@@ -1,4 +1,5 @@
 # ARG --enable-visitor-codes-regex=TRIO103
+# NOANYIO - not interesting, and cumbersome with the error message differences
 # check that partly disabling a visitor works
 from typing import Any
 

--- a/tests/eval_files/trio104.py
+++ b/tests/eval_files/trio104.py
@@ -1,4 +1,5 @@
 # ARG --enable-visitor-codes-regex=(TRIO103)|(TRIO104)
+# NOANYIO - not implemented
 
 import trio
 

--- a/tests/eval_files/trio105.py
+++ b/tests/eval_files/trio105.py
@@ -1,3 +1,4 @@
+# NOANYIO
 import trio
 
 
@@ -22,31 +23,31 @@ async def foo():
     await trio.sleep_until()
 
     # all async functions
-    trio.aclose_forcefully()  # error: 4, "aclose_forcefully"
-    trio.open_file()  # error: 4, "open_file"
-    trio.open_ssl_over_tcp_listeners()  # error: 4, "open_ssl_over_tcp_listeners"
-    trio.open_ssl_over_tcp_stream()  # error: 4, "open_ssl_over_tcp_stream"
-    trio.open_tcp_listeners()  # error: 4, "open_tcp_listeners"
-    trio.open_tcp_stream()  # error: 4, "open_tcp_stream"
-    trio.open_unix_socket()  # error: 4, "open_unix_socket"
-    trio.run_process()  # error: 4, "run_process"
-    trio.serve_listeners()  # error: 4, "serve_listeners"
-    trio.serve_ssl_over_tcp()  # error: 4, "serve_ssl_over_tcp"
-    trio.serve_tcp()  # error: 4, "serve_tcp"
-    trio.sleep()  # error: 4, "sleep"
-    trio.sleep_forever()  # error: 4, "sleep_forever"
-    trio.sleep_until()  # error: 4, "sleep_until"
+    trio.aclose_forcefully()  # error: 4, "aclose_forcefully", "trio"
+    trio.open_file()  # error: 4, "open_file", "trio"
+    trio.open_ssl_over_tcp_listeners()  # error: 4, "open_ssl_over_tcp_listeners", "trio"
+    trio.open_ssl_over_tcp_stream()  # error: 4, "open_ssl_over_tcp_stream", "trio"
+    trio.open_tcp_listeners()  # error: 4, "open_tcp_listeners", "trio"
+    trio.open_tcp_stream()  # error: 4, "open_tcp_stream", "trio"
+    trio.open_unix_socket()  # error: 4, "open_unix_socket", "trio"
+    trio.run_process()  # error: 4, "run_process", "trio"
+    trio.serve_listeners()  # error: 4, "serve_listeners", "trio"
+    trio.serve_ssl_over_tcp()  # error: 4, "serve_ssl_over_tcp", "trio"
+    trio.serve_tcp()  # error: 4, "serve_tcp", "trio"
+    trio.sleep()  # error: 4, "sleep", "trio"
+    trio.sleep_forever()  # error: 4, "sleep_forever", "trio"
+    trio.sleep_until()  # error: 4, "sleep_until", "trio"
 
     # safe
     async with await trio.open_file() as f:
         pass
 
-    async with trio.open_file() as f:  # error: 15, "open_file"
+    async with trio.open_file() as f:  # error: 15, "open_file", "trio"
         pass
 
     # safe in theory, but deemed sufficiently poor style that parsing
     # it isn't supported
-    k = trio.open_file()  # error: 8, "open_file"
+    k = trio.open_file()  # error: 8, "open_file", "trio"
     await k
 
     # issue #56
@@ -54,7 +55,7 @@ async def foo():
     await nursery.start()
     await nursery.start_foo()
 
-    nursery.start()  # error: 4, "start"
+    nursery.start()  # error: 4, "start", "nursery"
     None.start()
     nursery.start_soon()
     nursery.start_foo()

--- a/tests/eval_files/trio105_anyio.py
+++ b/tests/eval_files/trio105_anyio.py
@@ -1,0 +1,13 @@
+# NOTRIO
+import anyio
+
+
+async def foo():
+    nursery = anyio.open_nursery()
+    await nursery.start()
+    await nursery.start_foo()
+
+    nursery.start()  # should not be triggered with anyio
+    None.start()
+    nursery.start_soon()
+    nursery.start_foo()

--- a/tests/eval_files/trio106.py
+++ b/tests/eval_files/trio106.py
@@ -1,10 +1,10 @@
 import importlib
 
 import trio
-import trio as foo  # error: 0
+import trio as foo  # error: 0, "trio"
 from foo import blah
-from trio import *  # type: ignore # noqa # error: 0
-from trio import blah, open_file as foo  # noqa # error: 0
+from trio import *  # type: ignore # noqa # error: 0, "trio"
+from trio import blah, open_file as foo  # noqa # error: 0, "trio"
 
 # Note that our tests exercise the Visitor classes, without going through the noqa filter later in flake8 - so these suppressions are picked up by our project-wide linter stack but not the tests.
 

--- a/tests/eval_files/trio109.py
+++ b/tests/eval_files/trio109.py
@@ -1,3 +1,4 @@
+import trio
 import trio as anything
 
 timeout = 10
@@ -8,12 +9,12 @@ async def foo():
 
 
 # args
-async def foo_1(timeout):  # error: 16
+async def foo_1(timeout):  # error: 16, "trio"
     ...
 
 
 # arg in args with default & annotation
-async def foo_2(timeout: int = 3):  # error: 16
+async def foo_2(timeout: int = 3):  # error: 16, "trio"
     ...
 
 
@@ -33,14 +34,14 @@ async def foo_5(
     timeouts,
     my_timeout,
     timeout_,
-    timeout,  # error: 4
+    timeout,  # error: 4, "trio"
 ):
     ...
 
 
 # posonlyargs
 async def foo_6(
-    timeout,  # error: 4
+    timeout,  # error: 4, "trio"
     /,
     bar,
 ):
@@ -50,7 +51,7 @@ async def foo_6(
 # kwonlyargs
 async def foo_7(
     *,
-    timeout,  # error: 4
+    timeout,  # error: 4, "trio"
 ):
     ...
 
@@ -58,7 +59,7 @@ async def foo_7(
 # kwonlyargs (and kw_defaults)
 async def foo_8(
     *,
-    timeout=5,  # error: 4
+    timeout=5,  # error: 4, "trio"
 ):
     ...
 

--- a/tests/eval_files/trio110.py
+++ b/tests/eval_files/trio110.py
@@ -4,21 +4,21 @@ import trio as noerror
 
 async def foo():
     # only trigger on while loop with body being exactly one sleep[_until] statement
-    while ...:  # error: 4
+    while ...:  # error: 4, "trio"
         await trio.sleep()
 
-    while ...:  # error: 4
+    while ...:  # error: 4, "trio"
         await trio.sleep_until()
 
     # nested
 
     while ...:  # safe
-        while ...:  # error: 8
+        while ...:  # error: 8, "trio"
             await trio.sleep()
         await trio.sleep()
 
     while ...:  # safe
-        while ...:  # error: 8
+        while ...:  # error: 8, "trio"
             await trio.sleep()
 
     ### the rest are all safe

--- a/tests/eval_files/trio115.py
+++ b/tests/eval_files/trio115.py
@@ -6,14 +6,14 @@ from trio import sleep
 
 async def afoo():
     # only error on exactly one argument, that is 0
-    await trio.sleep(0)  # error: 10
+    await trio.sleep(0)  # error: 10, "trio"
     await trio.sleep(1)
     await trio.sleep(0, 1)
     await trio.sleep(...)
     await trio.sleep()
 
     # don't require it being await'ed
-    trio.sleep(0)  # error: 4
+    trio.sleep(0)  # error: 4, "trio"
     trio.sleep(1)
 
     # don't error on other sleeps
@@ -22,10 +22,10 @@ async def afoo():
 
 
 # don't require being inside a function
-trio.sleep(0)  # error: 0
+trio.sleep(0)  # error: 0, "trio"
 
 
 def foo():
     # can be inside a sync function, and inside other calls
     # (though yes this is invalid code)
-    trio.run(trio.sleep(0))  # error: 13
+    trio.run(trio.sleep(0))  # error: 13, "trio"

--- a/tests/eval_files/trio116.py
+++ b/tests/eval_files/trio116.py
@@ -6,20 +6,20 @@ import trio
 
 async def foo():
     # These examples are probably not meant to ever wake up:
-    await trio.sleep(100000)  # error: 10
+    await trio.sleep(100000)  # error: 10, "trio"
 
     # and these ones _definitely_ never wake up:
-    await trio.sleep(float("inf"))  # error: 10
-    await trio.sleep(math.inf)  # error: 10
-    await trio.sleep(inf)  # error: 10
+    await trio.sleep(float("inf"))  # error: 10, "trio"
+    await trio.sleep(math.inf)  # error: 10, "trio"
+    await trio.sleep(inf)  # error: 10, "trio"
 
     # 'inf literal' overflow trick
-    await trio.sleep(1e999)  # error: 10
+    await trio.sleep(1e999)  # error: 10, "trio"
 
     await trio.sleep(86399)
     await trio.sleep(86400)
-    await trio.sleep(86400.01)  # error: 10
-    await trio.sleep(86401)  # error: 10
+    await trio.sleep(86400.01)  # error: 10, "trio"
+    await trio.sleep(86401)  # error: 10, "trio"
 
     await trio.sleep(-1)  # will raise a runtime error from Trio
     await trio.sleep(0)  # handled by different check
@@ -34,14 +34,14 @@ async def foo():
     await trio.sleep(...)
 
     # don't require inf to be in math #103
-    await trio.sleep(np.inf)  # error: 10
-    await trio.sleep(anything.inf)  # error: 10
-    await trio.sleep(anything.anything.inf)  # error: 10
-    await trio.sleep(inf.inf)  # error: 10
+    await trio.sleep(np.inf)  # error: 10, "trio"
+    await trio.sleep(anything.inf)  # error: 10, "trio"
+    await trio.sleep(anything.anything.inf)  # error: 10, "trio"
+    await trio.sleep(inf.inf)  # error: 10, "trio"
     await trio.sleep(inf.anything)
 
 
 # does not require the call to be awaited, nor in an async fun
-trio.sleep(86401)  # error: 0
+trio.sleep(86401)  # error: 0, "trio"
 # also checks that we don't break visit_Call
-trio.run(trio.sleep(86401))  # error: 9
+trio.run(trio.sleep(86401))  # error: 9, "trio"

--- a/tests/eval_files/trio117.py
+++ b/tests/eval_files/trio117.py
@@ -1,4 +1,6 @@
+# ANYIO_NO_ERROR
 # Conventional usage
+
 try:
     raise MultiError  # TRIO117: 10, "MultiError"
     raise NonBaseMultiError  # TRIO117: 10, "NonBaseMultiError"

--- a/tests/eval_files/trio22x.py
+++ b/tests/eval_files/trio22x.py
@@ -2,68 +2,70 @@
 
 
 async def foo():
-    subprocess.Popen()  # TRIO220: 4, 'subprocess.Popen'
-    os.system()  # TRIO221: 4, 'os.system'
+    subprocess.Popen()  # TRIO220: 4, 'subprocess.Popen', "trio"
+    os.system()  # TRIO221: 4, 'os.system', "trio"
 
     system()
     os.system.anything()
     os.anything()
 
-    subprocess.run()  # TRIO221: 4, 'subprocess.run'
-    subprocess.call()  # TRIO221: 4, 'subprocess.call'
-    subprocess.check_call()  # TRIO221: 4, 'subprocess.check_call'
-    subprocess.check_output()  # TRIO221: 4, 'subprocess.check_output'
-    subprocess.getoutput()  # TRIO221: 4, 'subprocess.getoutput'
-    subprocess.getstatusoutput()  # TRIO221: 4, 'subprocess.getstatusoutput'
+    subprocess.run()  # TRIO221: 4, 'subprocess.run', "trio"
+    subprocess.call()  # TRIO221: 4, 'subprocess.call', "trio"
+    subprocess.check_call()  # TRIO221: 4, 'subprocess.check_call', "trio"
+    subprocess.check_output()  # TRIO221: 4, 'subprocess.check_output', "trio"
+    subprocess.getoutput()  # TRIO221: 4, 'subprocess.getoutput', "trio"
+    subprocess.getstatusoutput()  # TRIO221: 4, 'subprocess.getstatusoutput', "trio"
 
-    await async_fun(subprocess.getoutput())  # TRIO221: 20, 'subprocess.getoutput'
+    await async_fun(
+        subprocess.getoutput()  # TRIO221: 8, 'subprocess.getoutput', "trio"
+    )
 
     subprocess.anything()
     subprocess.foo()
     subprocess.bar.foo()
     subprocess()
 
-    os.posix_spawn()  # TRIO221: 4, 'os.posix_spawn'
-    os.posix_spawnp()  # TRIO221: 4, 'os.posix_spawnp'
+    os.posix_spawn()  # TRIO221: 4, 'os.posix_spawn', "trio"
+    os.posix_spawnp()  # TRIO221: 4, 'os.posix_spawnp', "trio"
 
     os.spawn()
     os.spawn
     os.spawnllll()
 
-    os.spawnl()  # TRIO221: 4,   'os.spawnl'
-    os.spawnle()  # TRIO221: 4,  'os.spawnle'
-    os.spawnlp()  # TRIO221: 4,  'os.spawnlp'
-    os.spawnlpe()  # TRIO221: 4, 'os.spawnlpe'
-    os.spawnv()  # TRIO221: 4,   'os.spawnv'
-    os.spawnve()  # TRIO221: 4,  'os.spawnve'
-    os.spawnvp()  # TRIO221: 4,  'os.spawnvp'
-    os.spawnvpe()  # TRIO221: 4, 'os.spawnvpe'
+    os.spawnl()  # TRIO221: 4,   'os.spawnl', "trio"
+    os.spawnle()  # TRIO221: 4,  'os.spawnle', "trio"
+    os.spawnlp()  # TRIO221: 4,  'os.spawnlp', "trio"
+    os.spawnlpe()  # TRIO221: 4, 'os.spawnlpe', "trio"
+    os.spawnv()  # TRIO221: 4,   'os.spawnv', "trio"
+    os.spawnve()  # TRIO221: 4,  'os.spawnve', "trio"
+    os.spawnvp()  # TRIO221: 4,  'os.spawnvp', "trio"
+    os.spawnvpe()  # TRIO221: 4, 'os.spawnvpe', "trio"
 
     # if mode is given, and is not os.P_WAIT: TRIO220
-    os.spawnl(os.P_NOWAIT)  # TRIO220: 4,   'os.spawnl'
-    os.spawnl(P_NOWAIT)  # TRIO220: 4,   'os.spawnl'
-    os.spawnl(mode=os.P_NOWAIT)  # TRIO220: 4,   'os.spawnl'
-    os.spawnl(mode=P_NOWAIT)  # TRIO220: 4,   'os.spawnl'
+    os.spawnl(os.P_NOWAIT)  # TRIO220: 4,   'os.spawnl', "trio"
+    os.spawnl(P_NOWAIT)  # TRIO220: 4,   'os.spawnl', "trio"
+    os.spawnl(mode=os.P_NOWAIT)  # TRIO220: 4,   'os.spawnl', "trio"
+    os.spawnl(mode=P_NOWAIT)  # TRIO220: 4,   'os.spawnl', "trio"
 
     # if it is P_WAIT, TRIO221
-    os.spawnl(os.P_WAIT)  # TRIO221: 4,   'os.spawnl'
-    os.spawnl(P_WAIT)  # TRIO221: 4,   'os.spawnl'
-    os.spawnl(mode=os.P_WAIT)  # TRIO221: 4,   'os.spawnl'
-    os.spawnl(mode=P_WAIT)  # TRIO221: 4,   'os.spawnl'
+    os.spawnl(os.P_WAIT)  # TRIO221: 4,   'os.spawnl', "trio"
+    os.spawnl(P_WAIT)  # TRIO221: 4,   'os.spawnl', "trio"
+    os.spawnl(mode=os.P_WAIT)  # TRIO221: 4,   'os.spawnl', "trio"
+    os.spawnl(mode=P_WAIT)  # TRIO221: 4,   'os.spawnl', "trio"
     # treating this as 221 to simplify code, and see no real reason not to
-    os.spawnl(foo.P_WAIT)  # TRIO221: 4,   'os.spawnl'
+    os.spawnl(foo.P_WAIT)  # TRIO221: 4,   'os.spawnl', "trio"
 
     # other weird cases: TRIO220
-    os.spawnl(0)  # TRIO220: 4,   'os.spawnl'
-    os.spawnl(1)  # TRIO220: 4,   'os.spawnl'
-    os.spawnl(foo())  # TRIO220: 4,   'os.spawnl'
+    os.spawnl(0)  # TRIO220: 4,   'os.spawnl', "trio"
+    os.spawnl(1)  # TRIO220: 4,   'os.spawnl', "trio"
+    os.spawnl(foo())  # TRIO220: 4,   'os.spawnl', "trio"
 
     # TRIO222
-    os.wait()  # TRIO222: 4, 'os.wait'
-    os.wait3()  # TRIO222: 4, 'os.wait3'
-    os.wait4()  # TRIO222: 4, 'os.wait4'
-    os.waitid()  # TRIO222: 4, 'os.waitid'
-    os.waitpid()  # TRIO222: 4, 'os.waitpid'
+    os.wait()  # TRIO222: 4, 'os.wait', "trio"
+    os.wait3()  # TRIO222: 4, 'os.wait3', "trio"
+    os.wait4()  # TRIO222: 4, 'os.wait4', "trio"
+    os.waitid()  # TRIO222: 4, 'os.waitid', "trio"
+    os.waitpid()  # TRIO222: 4, 'os.waitpid', "trio"
 
     os.waitpi()
     os.waiti()

--- a/tests/eval_files/trio232.py
+++ b/tests/eval_files/trio232.py
@@ -6,72 +6,72 @@ blah: Any = None
 
 
 async def file_text(f: io.TextIOWrapper):
-    f.read()  # TRIO232: 4, 'read', 'f'
-    f.readlines()  # TRIO232: 4, 'readlines', 'f'
+    f.read()  # TRIO232: 4, 'read', 'f', "trio"
+    f.readlines()  # TRIO232: 4, 'readlines', 'f', "trio"
 
     # there might be non-sync calls on TextIOWrappers? - but it will currently trigger
     # on all calls
-    f.anything()  # TRIO232: 4, 'anything', 'f'
+    f.anything()  # TRIO232: 4, 'anything', 'f', "trio"
 
 
 async def file_binary_read(f: io.BufferedReader):
-    f.read()  # TRIO232: 4, 'read', 'f'
+    f.read()  # TRIO232: 4, 'read', 'f', "trio"
 
 
 async def file_binary_write(f: io.BufferedWriter):
-    f.read()  # TRIO232: 4, 'read', 'f'
+    f.read()  # TRIO232: 4, 'read', 'f', "trio"
 
 
 async def file_binary_readwrite(f: io.BufferedRandom):
-    f.read()  # TRIO232: 4, 'read', 'f'
+    f.read()  # TRIO232: 4, 'read', 'f', "trio"
 
 
 async def file_text_(f: TextIOWrapper):
-    f.read()  # TRIO232: 4, 'read', 'f'
+    f.read()  # TRIO232: 4, 'read', 'f', "trio"
 
 
 async def file_binary_read_(f: BufferedReader):
-    f.read()  # TRIO232: 4, 'read', 'f'
+    f.read()  # TRIO232: 4, 'read', 'f', "trio"
 
 
 async def file_binary_write_(f: BufferedWriter):
-    f.read()  # TRIO232: 4, 'read', 'f'
+    f.read()  # TRIO232: 4, 'read', 'f', "trio"
 
 
 async def file_binary_readwrite_(f: BufferedRandom):
-    f.read()  # TRIO232: 4, 'read', 'f'
+    f.read()  # TRIO232: 4, 'read', 'f', "trio"
 
 
 async def file_text_3(f: TextIOWrapper = blah):
-    f.read()  # TRIO232: 4, 'read', 'f'
+    f.read()  # TRIO232: 4, 'read', 'f', "trio"
 
 
 async def file_text_4(f: TextIOWrapper | None):
-    f.read()  # TRIO232: 4, 'read', 'f'
+    f.read()  # TRIO232: 4, 'read', 'f', "trio"
     if f:
-        f.read()  # TRIO232: 8, 'read', 'f'
+        f.read()  # TRIO232: 8, 'read', 'f', "trio"
 
 
 async def file_text_5(f: TextIOWrapper | None = None):
-    f.read()  # TRIO232: 4, 'read', 'f'
+    f.read()  # TRIO232: 4, 'read', 'f', "trio"
     if f:
-        f.read()  # TRIO232: 8, 'read', 'f'
+        f.read()  # TRIO232: 8, 'read', 'f', "trio"
 
 
 async def file_text_6(f: Optional[TextIOWrapper] = None):
-    f.read()  # TRIO232: 4, 'read', 'f'
+    f.read()  # TRIO232: 4, 'read', 'f', "trio"
     if f:
-        f.read()  # TRIO232: 8, 'read', 'f'
+        f.read()  # TRIO232: 8, 'read', 'f', "trio"
 
 
 # posonly
 async def file_text_7(f: TextIOWrapper = blah, /):
-    f.read()  # TRIO232: 4, 'read', 'f'
+    f.read()  # TRIO232: 4, 'read', 'f', "trio"
 
 
 # keyword-only
 async def file_text_8(*, f: TextIOWrapper = blah):
-    f.read()  # TRIO232: 4, 'read', 'f'
+    f.read()  # TRIO232: 4, 'read', 'f', "trio"
 
 
 async def file_text_9(lf: list[TextIOWrapper]):
@@ -91,7 +91,7 @@ async def open_file_2():
 
 async def open_file_3():
     with open("") as f:
-        f.read()  # TRIO232: 8, 'read', 'f'
+        f.read()  # TRIO232: 8, 'read', 'f', "trio"
 
 
 async def open_file_4():
@@ -100,14 +100,14 @@ async def open_file_4():
 
 async def open_file_5():
     f = open("")
-    f.read()  # TRIO232: 4, 'read', 'f'
+    f.read()  # TRIO232: 4, 'read', 'f', "trio"
 
 
 async def open_file_6():
     ff = open("")
     f = ff
-    f.read()  # TRIO232: 4, 'read', 'f'
-    ff.read()  # TRIO232: 4, 'read', 'ff'
+    f.read()  # TRIO232: 4, 'read', 'f', "trio"
+    ff.read()  # TRIO232: 4, 'read', 'ff', "trio"
 
 
 async def noerror():
@@ -117,19 +117,19 @@ async def noerror():
 
 def sync_fun(f: TextIOWrapper):
     async def async_fun():
-        f.read()  # TRIO232: 8, 'read', 'f'
+        f.read()  # TRIO232: 8, 'read', 'f', "trio"
 
 
 def sync_fun_2():
     f = open("")
 
     async def async_fun():
-        f.read()  # TRIO232: 8, 'read', 'f'
+        f.read()  # TRIO232: 8, 'read', 'f', "trio"
 
 
 async def type_assign():
     f: TextIOWrapper = ...
-    f.read()  # TRIO232: 4, 'read', 'f'
+    f.read()  # TRIO232: 4, 'read', 'f', "trio"
 
 
 # define global variables
@@ -147,16 +147,16 @@ async def async_wrapper(f: TextIOWrapper):
 
         f.read()
 
-    f.read()  # TRIO232: 4, 'read', 'f'
+    f.read()  # TRIO232: 4, 'read', 'f', "trio"
     lambda f: f.read()
-    f.read()  # TRIO232: 4, 'read', 'f'
-    f.read()  # TRIO232: 4, 'read', 'f'
+    f.read()  # TRIO232: 4, 'read', 'f', "trio"
+    f.read()  # TRIO232: 4, 'read', 'f', "trio"
 
 
 # and show that they're still marked as TextIOWrappers
 async def global_vars():
-    f.read()  # TRIO232: 4, 'read', 'f'
-    g.read()  # TRIO232: 4, 'read', 'g'
+    f.read()  # TRIO232: 4, 'read', 'f', "trio"
+    g.read()  # TRIO232: 4, 'read', 'g', "trio"
 
 
 # If the type is explicitly overridden, it will not error
@@ -164,11 +164,11 @@ async def overridden_type(f: TextIOWrapper):
     f: int = 7
     f.read()
     f: TextIOWrapper = ...
-    f.read()  # TRIO232: 4, 'read', 'f'
+    f.read()  # TRIO232: 4, 'read', 'f', "trio"
     f: int = 7
     f.read()
     f: TextIOWrapper = ...
-    f.read()  # TRIO232: 4, 'read', 'f'
+    f.read()  # TRIO232: 4, 'read', 'f', "trio"
 
 
 # ***** Known unhandled cases *****
@@ -178,9 +178,9 @@ async def overridden_type(f: TextIOWrapper):
 async def implicit_overridden_type():
     f: TextIOWrapper = ...
     f = arbitrary_function()
-    f.read()  # TRIO232: 4, 'read', 'f'
+    f.read()  # TRIO232: 4, 'read', 'f', "trio"
     f = 7
-    f.read()  # TRIO232: 4, 'read', 'f'
+    f.read()  # TRIO232: 4, 'read', 'f', "trio"
 
 
 # Tuple assignments are completely ignored
@@ -206,13 +206,13 @@ async def attribute_access_on_object():
 # to the type
 async def type_restricting_1(f: Optional[TextIOWrapper] = None):
     if f is None:
-        f.read()  # TRIO232: 8, 'read', 'f'
+        f.read()  # TRIO232: 8, 'read', 'f', "trio"
 
 
 async def type_restricting_2(f: Optional[TextIOWrapper] = None):
     if isinstance(f, TextIOWrapper):
         return
-    f.read()  # TRIO232: 4, 'read', 'f'
+    f.read()  # TRIO232: 4, 'read', 'f', "trio"
 
 
 # Classes are not supported, partly due to not handling attributes at all,

--- a/tests/eval_files/trio23x.py
+++ b/tests/eval_files/trio23x.py
@@ -6,9 +6,9 @@ import trio
 
 
 async def foo():
-    open("")  # TRIO230: 4, 'open'
-    io.open_code("")  # TRIO230: 4, 'io.open_code'
-    os.fdopen(0)  # TRIO231: 4, 'os.fdopen'
+    open("")  # TRIO230: 4, 'open', "trio"
+    io.open_code("")  # TRIO230: 4, 'io.open_code', "trio"
+    os.fdopen(0)  # TRIO231: 4, 'os.fdopen', "trio"
 
     # sync call is awaited, so it can't be sync
     await open("")
@@ -18,15 +18,15 @@ async def foo():
     await trio.wrap_file(os.fdopen(0))
 
     # with uses the same code & logic
-    with os.fdopen(0):  # TRIO231: 9, 'os.fdopen'
+    with os.fdopen(0):  # TRIO231: 9, 'os.fdopen', "trio"
         ...
-    with open(""):  # TRIO230: 9, 'open'
+    with open(""):  # TRIO230: 9, 'open', "trio"
         ...
-    with open("") as f:  # TRIO230: 9, 'open'
+    with open("") as f:  # TRIO230: 9, 'open', "trio"
         ...
-    with foo(), open(""):  # TRIO230: 16, 'open'
+    with foo(), open(""):  # TRIO230: 16, 'open', "trio"
         ...
-    async with open(""):  # TRIO230: 15, 'open'
+    async with open(""):  # TRIO230: 15, 'open', "trio"
         ...
     async with trio.wrap_file(open("")):
         ...
@@ -35,7 +35,7 @@ async def foo():
     # pyupgrade removes the unnecessary `io.`
     # https://github.com/asottile/pyupgrade#open-alias
     # and afaict neither respects fmt:off nor #noqa - so I don't know how to test it
-    open("")  # TRIO230: 4, 'open'
+    open("")  # TRIO230: 4, 'open', "trio"
 
 
 def foo_sync():

--- a/tests/eval_files/trio240.py
+++ b/tests/eval_files/trio240.py
@@ -1,32 +1,32 @@
 import os.path
-from os.path import isfile, normpath, relpath  # ....
+from os.path import isfile, normpath, relpath
 
 
 async def foo():
-    normpath("")  # TRIO240: 4, 'normpath'
-    relpath("")  # TRIO240: 4, 'relpath'
-    isfile("")  # TRIO240: 4, 'isfile'
+    normpath("")  # TRIO240: 4, 'normpath', "trio"
+    relpath("")  # TRIO240: 4, 'relpath', "trio"
+    isfile("")  # TRIO240: 4, 'isfile', "trio"
 
-    os.path._path_normpath(...)  # TRIO240: 4, '_path_normpath'
-    os.path.normpath("")  # TRIO240: 4, 'normpath'
-    os.path._joinrealpath(...)  # TRIO240: 4, '_joinrealpath'
-    os.path.islink("")  # TRIO240: 4, 'islink'
-    os.path.lexists("")  # TRIO240: 4, 'lexists'
-    os.path.ismount("")  # TRIO240: 4, 'ismount'
-    os.path.realpath("")  # TRIO240: 4, 'realpath'
-    os.path.exists("")  # TRIO240: 4, 'exists'
-    os.path.isdir("")  # TRIO240: 4, 'isdir'
-    os.path.isfile("")  # TRIO240: 4, 'isfile'
-    os.path.getatime("")  # TRIO240: 4, 'getatime'
-    os.path.getctime("")  # TRIO240: 4, 'getctime'
-    os.path.getmtime("")  # TRIO240: 4, 'getmtime'
-    os.path.getsize("")  # TRIO240: 4, 'getsize'
-    os.path.samefile("", "")  # TRIO240: 4, 'samefile'
-    os.path.sameopenfile(0, 1)  # TRIO240: 4, 'sameopenfile'
-    os.path.relpath("")  # TRIO240: 4, 'relpath'
+    os.path._path_normpath(...)  # TRIO240: 4, '_path_normpath', "trio"
+    os.path.normpath("")  # TRIO240: 4, 'normpath', "trio"
+    os.path._joinrealpath(...)  # TRIO240: 4, '_joinrealpath', "trio"
+    os.path.islink("")  # TRIO240: 4, 'islink', "trio"
+    os.path.lexists("")  # TRIO240: 4, 'lexists', "trio"
+    os.path.ismount("")  # TRIO240: 4, 'ismount', "trio"
+    os.path.realpath("")  # TRIO240: 4, 'realpath', "trio"
+    os.path.exists("")  # TRIO240: 4, 'exists', "trio"
+    os.path.isdir("")  # TRIO240: 4, 'isdir', "trio"
+    os.path.isfile("")  # TRIO240: 4, 'isfile', "trio"
+    os.path.getatime("")  # TRIO240: 4, 'getatime', "trio"
+    os.path.getctime("")  # TRIO240: 4, 'getctime', "trio"
+    os.path.getmtime("")  # TRIO240: 4, 'getmtime', "trio"
+    os.path.getsize("")  # TRIO240: 4, 'getsize', "trio"
+    os.path.samefile("", "")  # TRIO240: 4, 'samefile', "trio"
+    os.path.sameopenfile(0, 1)  # TRIO240: 4, 'sameopenfile', "trio"
+    os.path.relpath("")  # TRIO240: 4, 'relpath', "trio"
 
-    await os.path.isfile("")  # TRIO240: 10, 'isfile'
-    print(os.path.isfile(""))  # TRIO240: 10, 'isfile'
+    await os.path.isfile("")  # TRIO240: 10, 'isfile', "trio"
+    print(os.path.isfile(""))  # TRIO240: 10, 'isfile', "trio"
     os.path.abspath("")
     os.path.anything("")
 

--- a/tests/eval_files/trio_anyio.py
+++ b/tests/eval_files/trio_anyio.py
@@ -1,0 +1,8 @@
+# ARG --enable-visitor-codes-regex=(TRIO220)
+# NOANYIO
+import trio  # isort: skip
+import anyio  # isort: skip
+
+
+async def foo():
+    subprocess.Popen()  # TRIO220: 4, 'subprocess.Popen', "[trio|anyio]"


### PR DESCRIPTION
Fixes #61
Have fun with this tiny commit :upside_down_face: 

Kind of a chore, I maybe should have gone at some parts in different ways, but the library should now have full support for anyio - and all eval files are tested with "trio" replaced with "anyio", looking to see that all the errors are still good, and that there's no instances of "trio" in the output.

If you trigger an error without importing either trio or anyio, the library will default to saying "trio" in error messages. If you trigger an error having imported both, it will say stuff like
> sync call ... in async function, use `[trio|anyio].open_file(...)`.

Otherwise it's not too much that's actually changed, just lots of small replacements in a billion places.