### PR TITLE
Add test that all error messages end with period, minor fixes

### DIFF
--- a/flake8_trio/visitors/flake8triovisitor.py
+++ b/flake8_trio/visitors/flake8triovisitor.py
@@ -87,7 +87,8 @@ class Flake8TrioVisitor(ast.NodeVisitor):
         if not self.suppress_errors:
             self._problems.append(
                 Error(
-                    error_code,
+                    # 7 == len('TRIO...'), so alt messages raise the original code
+                    error_code[:7],
                     node.lineno,
                     node.col_offset,
                     self.error_codes[error_code],

--- a/flake8_trio/visitors/visitor102.py
+++ b/flake8_trio/visitors/visitor102.py
@@ -18,7 +18,7 @@ class Visitor102(Flake8TrioVisitor):
     error_codes = {
         "TRIO102": (
             "await inside {0.name} on line {0.lineno} must have shielded cancel "
-            "scope with a timeout"
+            "scope with a timeout."
         ),
     }
 

--- a/flake8_trio/visitors/visitor2xx.py
+++ b/flake8_trio/visitors/visitor2xx.py
@@ -133,9 +133,9 @@ class TypeTrackerVisitor200(Visitor200):
 @error_class
 class Visitor21X(Visitor200):
     error_codes = {
-        "TRIO210": "Sync HTTP call {} in async function, use httpx.AsyncClient",
+        "TRIO210": "Sync HTTP call {} in async function, use `httpx.AsyncClient`.",
         "TRIO211": (
-            "Likely sync HTTP call {} in async function, use httpx.AsyncClient"
+            "Likely sync HTTP call {} in async function, use `httpx.AsyncClient`."
         ),
     }
 
@@ -193,7 +193,7 @@ class Visitor21X(Visitor200):
 class Visitor212(TypeTrackerVisitor200):
     error_codes = {
         "TRIO212": (
-            "Blocking sync HTTP call {1} on httpx object {0}, use httpx.AsyncClient"
+            "Blocking sync HTTP call {1} on httpx object {0}, use httpx.AsyncClient."
         )
     }
 
@@ -246,10 +246,10 @@ class Visitor22X(Visitor200):
     error_codes = {
         "TRIO220": (
             "Sync call {} in async function, use "
-            "`await nursery.start({}.run_process, ...)`"
+            "`await nursery.start({}.run_process, ...)`."
         ),
-        "TRIO221": "Sync call {} in async function, use `await {}.run_process(...)`",
-        "TRIO222": "Sync call {} in async function, wrap in `{}.to_thread.run_sync()`",
+        "TRIO221": "Sync call {} in async function, use `await {}.run_process(...)`.",
+        "TRIO222": "Sync call {} in async function, wrap in `{}.to_thread.run_sync()`.",
     }
 
     def visit_blocking_call(self, node: ast.Call):
@@ -331,7 +331,7 @@ class Visitor232(TypeTrackerVisitor200):
     error_codes = {
         "TRIO232": (
             "Blocking sync call {1} on file object {0}, wrap the file object"
-            "in `{2}.wrap_file()` to get an async file object"
+            "in `{2}.wrap_file()` to get an async file object."
         )
     }
 
@@ -358,7 +358,7 @@ class Visitor232(TypeTrackerVisitor200):
 @error_class
 class Visitor24X(Visitor200):
     error_codes = {
-        "TRIO240": ("Avoid using os.path, prefer using {1}.Path objects"),
+        "TRIO240": ("Avoid using os.path, prefer using {1}.Path objects."),
     }
 
     def __init__(self, *args: Any, **kwargs: Any):

--- a/flake8_trio/visitors/visitor91x.py
+++ b/flake8_trio/visitors/visitor91x.py
@@ -41,11 +41,11 @@ class Visitor91X(Flake8TrioVisitor):
     error_codes = {
         "TRIO910": (
             "{0} from async function with no guaranteed checkpoint or exception "
-            "since function definition on line {1.lineno}"
+            "since function definition on line {1.lineno}."
         ),
         "TRIO911": (
             "{0} from async iterable with no guaranteed checkpoint since {1.name} "
-            "on line {1.lineno}"
+            "on line {1.lineno}."
         ),
     }
 

--- a/flake8_trio/visitors/visitors.py
+++ b/flake8_trio/visitors/visitors.py
@@ -23,7 +23,7 @@ class Visitor100(Flake8TrioVisitor):
     error_codes = {
         "TRIO100": (
             "{0}.{1} context contains no checkpoints, remove the context or add"
-            " `await {0}.lowlevel.checkpoint()`"
+            " `await {0}.lowlevel.checkpoint()`."
         ),
     }
 
@@ -44,8 +44,8 @@ class Visitor100(Flake8TrioVisitor):
 class Visitor101(Flake8TrioVisitor):
     error_codes = {
         "TRIO101": (
-            "yield inside a nursery or cancel scope is only safe when implementing "
-            "a context manager - otherwise, it breaks exception handling"
+            "`yield` inside a nursery or cancel scope is only safe when implementing "
+            "a context manager - otherwise, it breaks exception handling."
         ),
     }
 
@@ -119,7 +119,7 @@ def is_nursery_call(node: ast.AST, name: str) -> bool:
 @error_class
 class Visitor105(Flake8TrioVisitor):
     error_codes = {
-        "TRIO105": "{1} async function {0} must be immediately awaited",
+        "TRIO105": "{1} async function {0} must be immediately awaited.",
     }
 
     def visit_Call(self, node: ast.Call):
@@ -140,7 +140,7 @@ class Visitor105(Flake8TrioVisitor):
 @error_class
 class Visitor106(Flake8TrioVisitor):
     error_codes = {
-        "TRIO106": "{0} must be imported with `import {0}` for the linter to work",
+        "TRIO106": "{0} must be imported with `import {0}` for the linter to work.",
     }
 
     def visit_ImportFrom(self, node: ast.ImportFrom):
@@ -158,7 +158,7 @@ class Visitor109(Flake8TrioVisitor):
     error_codes = {
         "TRIO109": (
             "Async function definition with a `timeout` parameter - use "
-            "`{}.[fail/move_on]_[after/at]` instead"
+            "`{}.[fail/move_on]_[after/at]` instead."
         ),
     }
 
@@ -198,7 +198,7 @@ class Visitor112(Flake8TrioVisitor):
     error_codes = {
         "TRIO112": (
             "Redundant nursery {}, consider replacing with directly awaiting "
-            "the function call"
+            "the function call."
         ),
     }
 
@@ -350,7 +350,7 @@ class Visitor116(Flake8TrioVisitor):
     error_codes = {
         "TRIO116": (
             "{0}.sleep() with >24 hour interval should usually be "
-            "`{0}.sleep_forever()`"
+            "`{0}.sleep_forever()`."
         ),
     }
 
@@ -390,7 +390,7 @@ DEPRECATED_ERRORS = ("MultiError", "NonBaseMultiError")
 @error_class
 class Visitor117(Flake8TrioVisitor):
     error_codes = {
-        "TRIO117": ("Reference to {}, prefer [exceptiongroup.]BaseExceptionGroup"),
+        "TRIO117": ("Reference to {}, prefer [exceptiongroup.]BaseExceptionGroup."),
     }
 
     # This should never actually happen given TRIO106

--- a/tests/eval_files/trio103.py
+++ b/tests/eval_files/trio103.py
@@ -23,7 +23,7 @@ try:
 except (
     SyntaxError,
     ValueError,
-    trio.Cancelled,  # error: 4, "trio.Cancelled", ""
+    trio.Cancelled,  # TRIO103: 4, "trio.Cancelled"
 ) as p:
     ...
 
@@ -44,13 +44,13 @@ except trio.Cancelled as e:
 
 try:
     ...
-except trio.Cancelled:  # error: 7, "trio.Cancelled", ""
+except trio.Cancelled:  # TRIO103: 7, "trio.Cancelled"
     ...
 
 # if
 try:
     ...
-except BaseException as e:  # error: 7, "BaseException", " Consider adding an `except trio.Cancelled: raise` before this exception handler."
+except BaseException as e:  # TRIO103_alt: 7, "BaseException"
     if True:
         raise e
     elif True:
@@ -60,7 +60,7 @@ except BaseException as e:  # error: 7, "BaseException", " Consider adding an `e
 
 try:
     ...
-except BaseException:  # error: 7, "BaseException", " Consider adding an `except trio.Cancelled: raise` before this exception handler."
+except BaseException:  # TRIO103_alt: 7, "BaseException"
     if True:
         raise
 
@@ -78,7 +78,7 @@ except BaseException:  # safe
 # raises inside the body are never guaranteed to run and are ignored
 try:
     ...
-except trio.Cancelled:  # error: 7, "trio.Cancelled", ""
+except trio.Cancelled:  # TRIO103: 7, "trio.Cancelled"
     while foo():
         raise
 
@@ -101,7 +101,7 @@ except trio.Cancelled:
 
 try:
     ...
-except BaseException:  # error: 7, "BaseException", " Consider adding an `except trio.Cancelled: raise` before this exception handler."
+except BaseException:  # TRIO103_alt: 7, "BaseException"
     while ...:
         if ...:
             break
@@ -111,7 +111,7 @@ except BaseException:  # error: 7, "BaseException", " Consider adding an `except
 
 try:
     ...
-except BaseException:  # error: 7, "BaseException", " Consider adding an `except trio.Cancelled: raise` before this exception handler."
+except BaseException:  # TRIO103_alt: 7, "BaseException"
     for _ in "":
         if ...:
             break
@@ -136,7 +136,7 @@ except BaseException:
 # But is a very weird pattern that we don't handle.
 try:
     ...
-except BaseException as e:  # error: 7, "BaseException", " Consider adding an `except trio.Cancelled: raise` before this exception handler."
+except BaseException as e:  # TRIO103_alt: 7, "BaseException"
     try:
         raise e
     except ValueError:
@@ -187,7 +187,7 @@ except trio.Cancelled as e:
 # bare except, equivalent to `except baseException`
 try:
     ...
-except:  # error: 0, "bare except", " Consider adding an `except trio.Cancelled: raise` before this exception handler."
+except:  # TRIO103_alt: 0, "bare except"
     ...
 
 try:
@@ -202,7 +202,7 @@ try:
 except (
     my_super_mega_long_exception_so_it_gets_split,
     SyntaxError,
-    BaseException,  # error: 4, "BaseException", " Consider adding an `except trio.Cancelled: raise` before this exception handler."
+    BaseException,  # TRIO103_alt: 4, "BaseException"
     ValueError,
     trio.Cancelled,  # no complaint on this line
 ):
@@ -217,13 +217,13 @@ except BaseException as e:
 
 try:
     ...
-except BaseException:  # error: 7, "BaseException", " Consider adding an `except trio.Cancelled: raise` before this exception handler."
+except BaseException:  # TRIO103_alt: 7, "BaseException"
     for i in [1, 2, 3]:
         ...
 
 try:
     ...
-except BaseException:  # error: 7, "BaseException", " Consider adding an `except trio.Cancelled: raise` before this exception handler."
+except BaseException:  # TRIO103_alt: 7, "BaseException"
     for i in [1, 2, 3]:
         if ...:
             continue
@@ -237,7 +237,7 @@ except BaseException:
 
 try:
     ...
-except BaseException:  # error: 7, "BaseException", " Consider adding an `except trio.Cancelled: raise` before this exception handler."
+except BaseException:  # TRIO103_alt: 7, "BaseException"
     while True:
         if ...:
             break
@@ -280,7 +280,7 @@ except:  # now silent
 # don't throw multiple 103's even if `Cancelled` wasn't properly handled.
 try:
     ...
-except trio.Cancelled:  # error: 7, "trio.Cancelled", ""
+except trio.Cancelled:  # TRIO103: 7, "trio.Cancelled"
     ...
 except BaseException:  # now silent
     ...
@@ -293,10 +293,10 @@ try:
         ...
     except trio.Cancelled:
         raise
-except trio.Cancelled:  # error: 7, "trio.Cancelled", ""
+except trio.Cancelled:  # TRIO103: 7, "trio.Cancelled"
     ...
 except:
     try:
         ...
-    except trio.Cancelled:  # error: 11, "trio.Cancelled", ""
+    except trio.Cancelled:  # TRIO103: 11, "trio.Cancelled"
         ...

--- a/tests/eval_files/trio103_no_104.py
+++ b/tests/eval_files/trio103_no_104.py
@@ -1,5 +1,5 @@
 # ARG --enable-visitor-codes-regex=TRIO103
-# NOANYIO - not interesting, and cumbersome with the error message differences
+# NOANYIO - TRIO103_alt not implemented for anyio
 # check that partly disabling a visitor works
 from typing import Any
 
@@ -13,7 +13,7 @@ def foo() -> Any:
 # But is a very weird pattern that we don't handle.
 try:
     ...
-except trio.Cancelled as e:  # error: 7, "trio.Cancelled", ""
+except BaseException as e:  # TRIO103_alt: 7, "BaseException"
     try:
         raise e
     except ValueError:

--- a/tests/eval_files/trio104.py
+++ b/tests/eval_files/trio104.py
@@ -29,7 +29,7 @@ except trio.Cancelled as e:
 # But is a very weird pattern that we don't handle.
 try:
     ...
-except BaseException as e:  # TRIO103: 7, "BaseException", " Consider adding an `except trio.Cancelled: raise` before this exception handler."
+except BaseException as e:  # TRIO103_alt: 7, "BaseException"
     try:
         raise e
     except ValueError:
@@ -93,13 +93,13 @@ def foo():
 
     try:
         ...
-    except BaseException:  # TRIO103: 11, "BaseException", " Consider adding an `except trio.Cancelled: raise` before this exception handler."
+    except BaseException:  # TRIO103_alt: 11, "BaseException"
         return  # error: 8
 
     # check that we properly iterate over all nodes in try
     try:
         ...
-    except BaseException:  # TRIO103: 11, "BaseException", " Consider adding an `except trio.Cancelled: raise` before this exception handler."
+    except BaseException:  # TRIO103_alt: 11, "BaseException"
         try:
             return  # error: 12
         except ValueError:

--- a/tests/test_changelog_and_version.py
+++ b/tests/test_changelog_and_version.py
@@ -56,7 +56,7 @@ def test_version_increments_are_correct():
             assert current == prev._replace(patch=prev.patch + 1), msg
 
 
-IGNORED_CODES = ("TRIO107", "TRIO108")
+IGNORED_CODES = ("TRIO107", "TRIO108", "TRIO103_alt")
 
 
 class test_messages_documented(unittest.TestCase):

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,0 +1,9 @@
+"""Test formatting in error codes."""
+
+from flake8_trio.visitors import ERROR_CLASSES
+
+
+def test_error_messages_ends_with_period():
+    for error_class in ERROR_CLASSES:
+        for code, message in error_class.error_codes.items():
+            assert message.endswith("."), f"{code} in {error_class} missing period."


### PR DESCRIPTION
Add test that all error messages end with period (and fix those that didn't). Add better implementation of alt messages for error codes. Also checks that errors in eval files with explicit codes are enabled.

Didn't wanna get started on something meaty but felt like doing something, so just some small maintenance/cleanup.