### PR TITLE
add TRIO118 - assigning [the value of] anyio.get_cancelled_exc_class to a variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Future
 - Rename TRIO107 to TRIO910, and TRIO108 to TRIO911, and making them optional by default.
+- Add TRIO118: Don't assign the value of `anyio.get_cancelled_exc_class()` to a variable, since that breaks linter checks and multi-backend programs.
 -
 ## 23.2.1
 - TRIO103 and TRIO104 no longer triggers when `trio.Cancelled` has been handled in previous except handlers.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ pip install flake8-trio
 - **TRIO115**: Replace `trio.sleep(0)` with the more suggestive `trio.lowlevel.checkpoint()`.
 - **TRIO116**: `trio.sleep()` with >24 hour interval should usually be`trio.sleep_forever()`.
 - **TRIO117**: Don't raise or catch `trio.[NonBase]MultiError`, prefer `[exceptiongroup.]BaseExceptionGroup`. Even if Trio still raises `MultiError` for legacy code, it can be caught with `BaseExceptionGroup` so it's fully redundant.
+- **TRIO118**: Don't assign the value of `anyio.get_cancelled_exc_class()` to a variable, since that breaks linter checks and multi-backend programs.
+
+### Warnings for blocking sync calls in async functions
 - **TRIO200**: User-configured error for blocking sync calls in async functions. Does nothing by default, see [`trio200-blocking-calls`](#trio200-blocking-calls) for how to configure it.
 - **TRIO210**: Sync HTTP call in async function, use `httpx.AsyncClient`.
 - **TRIO211**: Likely sync HTTP call in async function, use `httpx.AsyncClient`. Looks for `urllib3` method calls on pool objects, but only matching on the method signature and not the object.

--- a/flake8_trio/visitors/__init__.py
+++ b/flake8_trio/visitors/__init__.py
@@ -20,6 +20,7 @@ default_disabled_error_codes: list[str] = []
 from . import visitor102  # isort: skip
 from . import visitor103_104  # isort: skip
 from . import visitor111  # isort: skip
+from . import visitor118  # isort: skip
 from . import visitor2xx  # isort: skip
 from . import visitor91x  # isort: skip
 from . import visitors  # isort: skip

--- a/flake8_trio/visitors/flake8triovisitor.py
+++ b/flake8_trio/visitors/flake8triovisitor.py
@@ -12,7 +12,9 @@ if TYPE_CHECKING:
     from argparse import Namespace
     from collections.abc import Iterable
 
-    HasLineCol = Union[ast.expr, ast.stmt, ast.arg, ast.excepthandler, Statement]
+    HasLineCol = Union[
+        ast.expr, ast.stmt, ast.arg, ast.excepthandler, ast.alias, Statement
+    ]
 
 
 class Flake8TrioVisitor(ast.NodeVisitor):

--- a/flake8_trio/visitors/visitor118.py
+++ b/flake8_trio/visitors/visitor118.py
@@ -1,0 +1,42 @@
+"""Visitor for TRIO118.
+
+Don't assign the value of `anyio.get_cancelled_exc_class()` to a variable, since
+that breaks linter checks and multi-backend programs.
+"""
+
+
+from __future__ import annotations
+
+import ast
+import re
+
+from .flake8triovisitor import Flake8TrioVisitor
+from .helpers import error_class
+
+
+@error_class
+class Visitor118(Flake8TrioVisitor):
+    error_codes = {
+        "TRIO118": (
+            "Don't assign the value of `anyio.get_cancelled_exc_class()` to a variable,"
+            " since that breaks linter checks and multi-backend programs."
+        )
+    }
+
+    def visit_Assign(self, node: ast.Assign | ast.AnnAssign):
+        if node.value is None:
+            return
+        name = ast.unparse(node.value)
+        if re.fullmatch(r"(anyio.)?get_cancelled_exc_class(\(\))?", name):
+            self.error(node.value)
+
+    visit_AnnAssign = visit_Assign
+
+    # redundant check with TRIO106
+    def visit_ImportFrom(self, node: ast.ImportFrom):
+        if node.module == "anyio":
+            for alias in node.names:
+                if alias.name == "get_cancelled_exc_class" and alias.asname is not None:
+                    # alias doesn't have a lineno in 3.9
+                    self.error(node)
+                    return

--- a/tests/eval_files/trio118.py
+++ b/tests/eval_files/trio118.py
@@ -1,0 +1,18 @@
+from typing import Any
+
+import anyio
+from anyio import get_cancelled_exc_class, get_cancelled_exc_class as foo  # TRIO118: 0
+
+bar1 = anyio.get_cancelled_exc_class  # TRIO118: 7
+bar2 = anyio.get_cancelled_exc_class()  # TRIO118: 7
+bar3 = get_cancelled_exc_class  # TRIO118: 7
+bar4 = get_cancelled_exc_class()  # TRIO118: 7
+
+bar5: Any = anyio.get_cancelled_exc_class  # TRIO118: 12
+bar6: Any = anyio.get_cancelled_exc_class()  # TRIO118: 12
+bar7: Any = get_cancelled_exc_class  # TRIO118: 12
+bar8: Any = get_cancelled_exc_class()  # TRIO118: 12
+
+# code coverage
+bar9: Any
+from anyio import sleep  # isort: skip

--- a/tests/test_flake8_trio.py
+++ b/tests/test_flake8_trio.py
@@ -216,6 +216,7 @@ error_codes_ignored_when_checking_transformed_sync_code = {
     "TRIO115",
     "TRIO116",
     "TRIO117",
+    "TRIO118",
 }
 
 


### PR DESCRIPTION
Fixes
> We probably also want to lint for "no assigning that result because it breaks our linter, as well as multi-backend programs".

from #122