### PR TITLE
Fix get_matching_call when passed a single string as base.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 *[CalVer, YY.month.patch](https://calver.org/)*
+## Future
+- Fix get_matching_call when passed a single string as base. Resolves possibly several false alarms, TRIO210 among them.
 
 ## 23.2.2
 - Rename TRIO107 to TRIO910, and TRIO108 to TRIO911, and making them optional by default.

--- a/flake8_trio/visitors/helpers.py
+++ b/flake8_trio/visitors/helpers.py
@@ -148,6 +148,8 @@ cancel_scope_names = (
 def get_matching_call(
     node: ast.AST, *names: str, base: Iterable[str] = ("trio", "anyio")
 ) -> tuple[ast.Call, str, str] | None:
+    if isinstance(base, str):
+        base = (base,)
     if (
         isinstance(node, ast.Call)
         and isinstance(node.func, ast.Attribute)

--- a/tests/eval_files/trio210.py
+++ b/tests/eval_files/trio210.py
@@ -37,3 +37,6 @@ async def foo():
     urllib.request.urlopen("")  # TRIO210: 4, 'urllib.request.urlopen'
     request.urlopen()  # TRIO210: 4, 'request.urlopen'
     urlopen()  # TRIO210: 4, 'urlopen'
+
+    r = {}
+    r.get("not a sync http client")


### PR DESCRIPTION
Fixes #129 
Introduced in 73c9fc50 when adding support for anyio.