### PR TITLE
Add anyio.TaskGroup support to TRIO113

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,8 @@ repos:
           - hypothesmith
           - pytest
           - flake8
+          - trio
+          - anyio
 
 -   repo: https://github.com/codespell-project/codespell
     rev: v2.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 *[CalVer, YY.month.patch](https://calver.org/)*
 
+## Future
+- TRIO113 now also works on anyio.TaskGroup
+
 ## 23.2.3
 - Fix get_matching_call when passed a single string as base. Resolves possibly several false alarms, TRIO210 among them.
 

--- a/flake8_trio/visitors/helpers.py
+++ b/flake8_trio/visitors/helpers.py
@@ -139,17 +139,6 @@ def critical_except(node: ast.ExceptHandler) -> Statement | None:
     return None
 
 
-# used in 105 and 113
-def is_nursery_call(node: ast.AST, name: str) -> bool:
-    assert name in ("start", "start_soon")
-    if isinstance(node, ast.Attribute):
-        if isinstance(node.value, ast.Name):
-            return node.attr == name and node.value.id.endswith("nursery")
-        if isinstance(node.value, ast.Attribute):
-            return node.attr == name and node.value.attr.endswith("nursery")
-    return False
-
-
 # used in 100, 101 and 102
 cancel_scope_names = (
     "fail_after",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.pyright]
 strict = ["*.py", "tests/test_flake8_trio.py", "tests/conftest.py"]
-exclude = ["tests/eval_files/*", "**/node_modules", "**/__pycache__", "**/.*"]
+exclude = ["**/node_modules", "**/__pycache__", "**/.*"]
 
 [tool.codespell]
 ignore-words-list = 'spawnve'

--- a/tests/eval_files/anyio_trio.py
+++ b/tests/eval_files/anyio_trio.py
@@ -1,3 +1,4 @@
+# type: ignore
 # ARG --enable-visitor-codes-regex=(TRIO220)
 # NOTRIO
 

--- a/tests/eval_files/no_library.py
+++ b/tests/eval_files/no_library.py
@@ -1,3 +1,4 @@
+# type: ignore
 # ARG --enable-visitor-codes-regex=(TRIO220)
 # NOANYIO
 async def foo():

--- a/tests/eval_files/trio100.py
+++ b/tests/eval_files/trio100.py
@@ -1,3 +1,4 @@
+# type: ignore
 import trio
 
 with trio.move_on_after(10):  # error: 5,"trio", "move_on_after"
@@ -35,10 +36,7 @@ async def function_name():
             pass
 
 
-import trio
-
-
-async def function_name():
+async def function_name2():
     with (
         open("") as _,
         trio.fail_after(10),  # error: 8, "trio", "fail_after"

--- a/tests/eval_files/trio101.py
+++ b/tests/eval_files/trio101.py
@@ -1,3 +1,4 @@
+# type: ignore
 import contextlib
 import contextlib as bla
 from contextlib import asynccontextmanager, contextmanager, contextmanager as blahabla

--- a/tests/eval_files/trio102.py
+++ b/tests/eval_files/trio102.py
@@ -1,3 +1,4 @@
+# type: ignore
 from contextlib import asynccontextmanager
 
 import trio

--- a/tests/eval_files/trio102_anyio.py
+++ b/tests/eval_files/trio102_anyio.py
@@ -1,3 +1,4 @@
+# type: ignore
 import anyio
 from anyio import get_cancelled_exc_class
 

--- a/tests/eval_files/trio104_anyio.py
+++ b/tests/eval_files/trio104_anyio.py
@@ -1,3 +1,4 @@
+# type: ignore
 import anyio
 
 try:

--- a/tests/eval_files/trio105.py
+++ b/tests/eval_files/trio105.py
@@ -1,53 +1,79 @@
 # NOANYIO
+from typing import Any
+
 import trio
+
+par: Any = ...
 
 
 async def foo():
     # not async
-    trio.run()
+    trio.run(par)
 
     # safely awaited
-    await trio.aclose_forcefully()
-    await trio.open_file()
-    await trio.open_ssl_over_tcp_listeners()
-    await trio.open_ssl_over_tcp_stream()
-    await trio.open_tcp_listeners()
-    await trio.open_tcp_stream()
-    await trio.open_unix_socket()
-    await trio.run_process()
-    await trio.serve_listeners()
+    await trio.aclose_forcefully(par)
+    await trio.open_file(par)
+    await trio.open_ssl_over_tcp_listeners(par, par)
+    await trio.open_ssl_over_tcp_stream(par, par)
+    await trio.open_tcp_listeners(par)
+    await trio.open_tcp_stream(par, par)
+    await trio.open_unix_socket(par)
+    await trio.run_process(par)
+    await trio.serve_listeners(par, par)
     await trio.serve_ssl_over_tcp()
     await trio.serve_tcp()
     await trio.sleep()
     await trio.sleep_forever()
     await trio.sleep_until()
+    await trio.lowlevel.cancel_shielded_checkpoint()
+    await trio.lowlevel.checkpoint()
+    await trio.lowlevel.checkpoint_if_cancelled()
+    await trio.lowlevel.open_process()
+    await trio.lowlevel.permanently_detach_coroutine_object()
+    await trio.lowlevel.reattach_detached_coroutine_object()
+    await trio.lowlevel.temporarily_detach_coroutine_object()
+    await trio.lowlevel.wait_readable()
+    await trio.lowlevel.wait_task_rescheduled()
+    await trio.lowlevel.wait_writable()
 
     # all async functions
-    trio.aclose_forcefully()  # error: 4, "aclose_forcefully", "trio"
-    trio.open_file()  # error: 4, "open_file", "trio"
-    trio.open_ssl_over_tcp_listeners()  # error: 4, "open_ssl_over_tcp_listeners", "trio"
-    trio.open_ssl_over_tcp_stream()  # error: 4, "open_ssl_over_tcp_stream", "trio"
-    trio.open_tcp_listeners()  # error: 4, "open_tcp_listeners", "trio"
-    trio.open_tcp_stream()  # error: 4, "open_tcp_stream", "trio"
-    trio.open_unix_socket()  # error: 4, "open_unix_socket", "trio"
-    trio.run_process()  # error: 4, "run_process", "trio"
-    trio.serve_listeners()  # error: 4, "serve_listeners", "trio"
-    trio.serve_ssl_over_tcp()  # error: 4, "serve_ssl_over_tcp", "trio"
-    trio.serve_tcp()  # error: 4, "serve_tcp", "trio"
-    trio.sleep()  # error: 4, "sleep", "trio"
-    trio.sleep_forever()  # error: 4, "sleep_forever", "trio"
-    trio.sleep_until()  # error: 4, "sleep_until", "trio"
+    trio.aclose_forcefully()  # error: 4, "trio.aclose_forcefully", "function"
+    trio.open_file()  # error: 4, "trio.open_file", "function"
+    trio.open_ssl_over_tcp_listeners()  # error: 4, "trio.open_ssl_over_tcp_listeners", "function"
+    trio.open_ssl_over_tcp_stream()  # error: 4, "trio.open_ssl_over_tcp_stream", "function"
+    trio.open_tcp_listeners()  # error: 4, "trio.open_tcp_listeners", "function"
+    trio.open_tcp_stream()  # error: 4, "trio.open_tcp_stream", "function"
+    trio.open_unix_socket()  # error: 4, "trio.open_unix_socket", "function"
+    trio.run_process()  # error: 4, "trio.run_process", "function"
+    trio.serve_listeners()  # error: 4, "trio.serve_listeners", "function"
+    trio.serve_ssl_over_tcp()  # error: 4, "trio.serve_ssl_over_tcp", "function"
+    trio.serve_tcp()  # error: 4, "trio.serve_tcp", "function"
+    trio.sleep()  # error: 4, "trio.sleep", "function"
+    trio.sleep_forever()  # error: 4, "trio.sleep_forever", "function"
+    trio.sleep_until()  # error: 4, "trio.sleep_until", "function"
+
+    # long lines, wheee
+    trio.lowlevel.cancel_shielded_checkpoint()  # error: 4, "trio.lowlevel.cancel_shielded_checkpoint", "function"
+    trio.lowlevel.checkpoint()  # error: 4, "trio.lowlevel.checkpoint", "function"
+    trio.lowlevel.checkpoint_if_cancelled()  # error: 4, "trio.lowlevel.checkpoint_if_cancelled", "function"
+    trio.lowlevel.open_process()  # error: 4, "trio.lowlevel.open_process", "function"
+    trio.lowlevel.permanently_detach_coroutine_object()  # error: 4, "trio.lowlevel.permanently_detach_coroutine_object", "function"
+    trio.lowlevel.reattach_detached_coroutine_object()  # error: 4, "trio.lowlevel.reattach_detached_coroutine_object", "function"
+    trio.lowlevel.temporarily_detach_coroutine_object()  # error: 4, "trio.lowlevel.temporarily_detach_coroutine_object", "function"
+    trio.lowlevel.wait_readable()  # error: 4, "trio.lowlevel.wait_readable", "function"
+    trio.lowlevel.wait_task_rescheduled()  # error: 4, "trio.lowlevel.wait_task_rescheduled", "function"
+    trio.lowlevel.wait_writable()  # error: 4, "trio.lowlevel.wait_writable", "function"
 
     # safe
     async with await trio.open_file() as f:
         pass
 
-    async with trio.open_file() as f:  # error: 15, "open_file", "trio"
+    async with trio.open_file() as f:  # error: 15, "trio.open_file", "function"
         pass
 
     # safe in theory, but deemed sufficiently poor style that parsing
     # it isn't supported
-    k = trio.open_file()  # error: 8, "open_file", "trio"
+    k = trio.open_file()  # error: 8, "trio.open_file", "function"
     await k
 
     # issue #56
@@ -55,7 +81,13 @@ async def foo():
     await nursery.start()
     await nursery.start_foo()
 
-    nursery.start()  # error: 4, "start", "nursery"
-    None.start()
+    nursery.start()  # error: 4, "trio.Nursery.start", "method"
+    None.start()  # type: ignore
     nursery.start_soon()
     nursery.start_foo()
+
+    with trio.open_nursery() as booboo:
+        booboo.start()  # error: 8, "trio.Nursery.start", "method"
+
+    barbar: trio.Nursery = ...
+    barbar.start()  # error: 4, "trio.Nursery.start", "method"

--- a/tests/eval_files/trio105_anyio.py
+++ b/tests/eval_files/trio105_anyio.py
@@ -4,11 +4,11 @@ import anyio
 
 # nurseries don't exist in anyio, so don't error on it.
 async def foo():
-    nursery = anyio.open_nursery()
+    nursery = anyio.open_nursery()  # type: ignore
     await nursery.start()
     await nursery.start_foo()
 
     nursery.start()  # should not be triggered with anyio
-    None.start()
+    None.start()  # type: ignore
     nursery.start_soon()
     nursery.start_foo()

--- a/tests/eval_files/trio106.py
+++ b/tests/eval_files/trio106.py
@@ -1,3 +1,4 @@
+# type: ignore
 import importlib
 
 import trio

--- a/tests/eval_files/trio109.py
+++ b/tests/eval_files/trio109.py
@@ -1,3 +1,4 @@
+# type: ignore
 import trio
 import trio as anything
 

--- a/tests/eval_files/trio110.py
+++ b/tests/eval_files/trio110.py
@@ -1,3 +1,4 @@
+# type: ignore
 import trio
 import trio as noerror
 

--- a/tests/eval_files/trio111.py
+++ b/tests/eval_files/trio111.py
@@ -1,3 +1,4 @@
+# type: ignore
 from typing import Any
 
 import trio

--- a/tests/eval_files/trio112.py
+++ b/tests/eval_files/trio112.py
@@ -1,3 +1,4 @@
+# type: ignore
 import functools
 from functools import partial
 

--- a/tests/eval_files/trio113.py
+++ b/tests/eval_files/trio113.py
@@ -1,123 +1,26 @@
-import contextlib
-import contextlib as arbitrary_import_alias_for_contextlib
-import functools
-import os
+# mypy: disable-error-code="arg-type,attr-defined"
 from contextlib import asynccontextmanager
-from functools import partial
 
+import anyio
 import trio
 
-# ARG --startable-in-context-manager=custom_startable_function
+# NOANYIO - requires no substitution check
 
 
 @asynccontextmanager
-async def custom_startable_externally_tested():
-    nursery.start_soon(custom_startable_function)  # error: 4
+async def foo():
+    with trio.open_nursery() as bar:
+        bar.start_soon(trio.run_process)  # TRIO113: 8
+    async with trio.open_nursery() as bar:
+        bar.start_soon(trio.run_process)  # TRIO113: 8
+
+    async with anyio.create_task_group() as bar_tg:
+        bar_tg.start_soon(anyio.run_process)  # TRIO113: 8
+
+    boo: trio.Nursery = ...  # type: ignore
+    boo.start_soon(trio.run_process)  # TRIO113: 4
+
+    boo_anyio: anyio.TaskGroup = ...  # type: ignore
+    boo_anyio.start_soon(anyio.run_process)  # TRIO113: 4
+
     yield
-
-
-@asynccontextmanager
-async def run_sampling_profiler():
-    async with trio.open_nursery() as nursery:
-        nursery.start_soon(  # error: 8
-            trio.run_process, ["start-sampling-profiler", str(os.getpid())]
-        )
-        yield
-
-        nursery.start_soon(  # safe, it's after the first yield
-            trio.run_process, ["start-sampling-profiler", str(os.getpid())]
-        )
-
-
-async def not_cm():
-    async with trio.open_nursery() as nursery:
-        nursery.start_soon(
-            trio.run_process, ["start-sampling-profiler", str(os.getpid())]
-        )
-        yield
-
-
-class foo:
-    async def __aenter__(self):
-        async with trio.open_nursery() as nursery:
-            nursery.start_soon(  # error: 12
-                trio.run_process, ["start-sampling-profiler", str(os.getpid())]
-            )
-            yield
-
-
-nursery = anything = custom_startable_function = anything_nursery = trio  # type: ignore
-
-
-class foo2:
-    _nursery = nursery
-
-    async def __aenter__(self):
-        nursery.start_soon(trio.run_process)  # error: 8
-        nursery.start_soon(trio.serve_ssl_over_tcp)  # error: 8
-        nursery.start_soon(trio.serve_tcp)  # error: 8
-        nursery.start_soon(trio.serve_listeners)  # error: 8
-
-        # Where does `nursery` come from in __aenter__?  Probably an attribute:
-        self._nursery.start_soon(trio.run_process)  # error: 8
-        self._nursery.start_soon(trio.serve_ssl_over_tcp)  # error: 8
-        self._nursery.start_soon(trio.serve_tcp)  # error: 8
-        self._nursery.start_soon(trio.serve_listeners)  # error: 8
-
-        # triggers on anything whose name ends with nursery
-        anything_nursery.start_soon(trio.run_process)  # error: 8
-        anything.start_soon(trio.run_process)
-        None.start_soon(trio.run_process)
-
-        # explicitly check partial support
-        nursery.start_soon(partial(trio.run_process))  # error: 8
-        nursery.start_soon(functools.partial(trio.run_process))  # error: 8
-        nursery.start_soon(anything.partial(trio.run_process))  # error: 8
-
-        # trigger when the sensitive methods are inside a call
-        nursery.start_soon(tuple(tuple(tuple(tuple(trio.run_process)))))  # error: 8
-        nursery.start_soon(None, tuple(tuple(tuple(tuple(trio.run_process)))))
-        nursery.start_soon(partial(print, 5))
-        nursery.start_soon(partial(print, trio.run_process))  # error: 8
-
-        serve = run_process = myfun = anything
-        # error if name shared with trio
-        nursery.start_soon(serve)  # error: 8
-        nursery.start_soon(run_process)  # error: 8
-        # don't error if a startable name is a parameter or module
-        nursery.start_soon(myfun(serve=None))
-        nursery.start_soon(serve.myfun)
-
-        # doesn't support more esoteric ways of baking in the name
-        nursery.start_soon(lambda x: serve(x))
-        nursery.start_soon([serve])
-
-
-class foo3:
-    async def __aenter__(_a_parameter_not_named_self):
-        nursery.start_soon(trio.run_process)  # error: 8
-
-
-# might be monkeypatched onto an instance, count this as an error too
-async def __aenter__():
-    nursery.start_soon(trio.run_process)  # error: 4
-    nursery.start_soon()  # broken code, but our analysis shouldn't crash
-    nursery.cancel_scope.cancel()
-
-
-@contextlib.asynccontextmanager
-async def contextlib_acm():
-    nursery.start_soon(trio.run_process)  # error: 4
-    yield
-
-
-@arbitrary_import_alias_for_contextlib.asynccontextmanager
-async def contextlib_import_alias_acm():
-    nursery.start_soon(trio.run_process)  # error: 4
-    yield
-
-
-# code coverage for non-name, non-attribute decorator
-@None
-async def foo4():
-    ...

--- a/tests/eval_files/trio113_trio.py
+++ b/tests/eval_files/trio113_trio.py
@@ -1,0 +1,129 @@
+# mypy: disable-error-code="arg-type,call-overload,misc"
+import contextlib
+import contextlib as arbitrary_import_alias_for_contextlib
+import functools
+import os
+from contextlib import asynccontextmanager
+from functools import partial
+from typing import Any
+
+import trio
+
+# ARG --startable-in-context-manager=custom_startable_function
+# NOANYIO
+
+
+@asynccontextmanager
+async def custom_startable_externally_tested():
+    nursery.start_soon(custom_startable_function)  # error: 4
+    yield
+
+
+@asynccontextmanager
+async def run_sampling_profiler():
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(  # error: 8
+            trio.run_process, ["start-sampling-profiler", str(os.getpid())]
+        )
+        yield
+
+        nursery.start_soon(  # safe, it's after the first yield
+            trio.run_process, ["start-sampling-profiler", str(os.getpid())]
+        )
+
+
+async def not_cm():
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(
+            trio.run_process, ["start-sampling-profiler", str(os.getpid())]
+        )
+        yield
+
+
+class foo:
+    async def __aenter__(self):
+        async with trio.open_nursery() as nursery:
+            nursery.start_soon(  # error: 12
+                trio.run_process, ["start-sampling-profiler", str(os.getpid())]
+            )
+            yield
+
+
+nursery: trio.Nursery = ...  # type: ignore
+anything_nursery = nursery
+anything: Any = ...
+custom_startable_function: Any = ...
+
+
+class foo2:
+    _nursery = nursery
+
+    async def __aenter__(self):
+        nursery.start_soon(trio.run_process)  # error: 8
+        nursery.start_soon(trio.serve_ssl_over_tcp)  # error: 8
+        nursery.start_soon(trio.serve_tcp)  # error: 8
+        nursery.start_soon(trio.serve_listeners)  # error: 8
+
+        # Where does `nursery` come from in __aenter__?  Probably an attribute:
+        self._nursery.start_soon(trio.run_process)  # error: 8
+        self._nursery.start_soon(trio.serve_ssl_over_tcp)  # error: 8
+        self._nursery.start_soon(trio.serve_tcp)  # error: 8
+        self._nursery.start_soon(trio.serve_listeners)  # error: 8
+
+        # triggers on anything whose name ends with nursery
+        anything_nursery.start_soon(trio.run_process)  # error: 8
+        anything.start_soon(trio.run_process)
+        None.start_soon(trio.run_process)  # type: ignore
+
+        # explicitly check partial support
+        nursery.start_soon(partial(trio.run_process))  # error: 8
+        nursery.start_soon(functools.partial(trio.run_process))  # error: 8
+        nursery.start_soon(anything.partial(trio.run_process))  # error: 8
+
+        # trigger when the sensitive methods are inside a call
+        nursery.start_soon(tuple(tuple(tuple(tuple(trio.run_process)))))  # error: 8
+        nursery.start_soon(None, tuple(tuple(tuple(tuple(trio.run_process)))))
+        nursery.start_soon(partial(print, 5))
+        nursery.start_soon(partial(print, trio.run_process))  # error: 8
+
+        serve = run_process = myfun = anything
+        # error if name shared with trio
+        nursery.start_soon(serve)  # error: 8
+        nursery.start_soon(run_process)  # error: 8
+        # don't error if a startable name is a parameter or module
+        nursery.start_soon(myfun(serve=None))
+        nursery.start_soon(serve.myfun)
+
+        # doesn't support more esoteric ways of baking in the name
+        nursery.start_soon(lambda x: serve(x))
+        nursery.start_soon([serve])
+
+
+class foo3:
+    async def __aenter__(_a_parameter_not_named_self):
+        nursery.start_soon(trio.run_process)  # error: 8
+
+
+# might be monkeypatched onto an instance, count this as an error too
+async def __aenter__():
+    nursery.start_soon(trio.run_process)  # error: 4
+    nursery.start_soon()  # broken code, but our analysis shouldn't crash
+    nursery.cancel_scope.cancel()
+
+
+@contextlib.asynccontextmanager
+async def contextlib_acm():
+    nursery.start_soon(trio.run_process)  # error: 4
+    yield
+
+
+@arbitrary_import_alias_for_contextlib.asynccontextmanager
+async def contextlib_import_alias_acm():
+    nursery.start_soon(trio.run_process)  # error: 4
+    yield
+
+
+# code coverage for non-name, non-attribute decorator
+@None  # type: ignore
+async def foo4():
+    ...

--- a/tests/eval_files/trio115.py
+++ b/tests/eval_files/trio115.py
@@ -1,3 +1,4 @@
+# type: ignore
 import time
 
 import trio

--- a/tests/eval_files/trio116.py
+++ b/tests/eval_files/trio116.py
@@ -1,3 +1,4 @@
+# type: ignore
 import math
 from math import inf
 

--- a/tests/eval_files/trio117.py
+++ b/tests/eval_files/trio117.py
@@ -1,5 +1,7 @@
+# type: ignore
 # ANYIO_NO_ERROR
 # Conventional usage
+from trio import MultiError
 
 try:
     raise MultiError  # TRIO117: 10, "MultiError"

--- a/tests/eval_files/trio200.py
+++ b/tests/eval_files/trio200.py
@@ -1,3 +1,4 @@
+# type: ignore
 # specify command-line arguments to be used when testing this file.
 # Test spaces in options, and trailing comma
 # Cannot test newlines, since argparse splits on those if passed on the CLI
@@ -5,7 +6,7 @@
 
 
 # don't error in sync function
-def foo():
+def bar():
     bar()
     bee.bonnet()
 

--- a/tests/eval_files/trio210.py
+++ b/tests/eval_files/trio210.py
@@ -1,3 +1,4 @@
+# type: ignore
 import urllib
 
 import httpx

--- a/tests/eval_files/trio211.py
+++ b/tests/eval_files/trio211.py
@@ -1,3 +1,4 @@
+# type: ignore
 from urllib3 import PoolManager
 
 

--- a/tests/eval_files/trio212.py
+++ b/tests/eval_files/trio212.py
@@ -1,3 +1,4 @@
+# type: ignore
 import urllib3
 
 

--- a/tests/eval_files/trio22x.py
+++ b/tests/eval_files/trio22x.py
@@ -1,3 +1,4 @@
+# type: ignore
 # ARG --enable-visitor-codes-regex=(TRIO220|TRIO221|TRIO222)
 
 

--- a/tests/eval_files/trio232.py
+++ b/tests/eval_files/trio232.py
@@ -1,3 +1,4 @@
+# type: ignore
 import io
 from io import BufferedRandom, BufferedReader, BufferedWriter, TextIOWrapper
 from typing import Any, Optional

--- a/tests/eval_files/trio23x.py
+++ b/tests/eval_files/trio23x.py
@@ -1,3 +1,4 @@
+# type: ignore
 # ARG --enable-visitor-codes-regex=(TRIO230)|(TRIO231)
 import io
 import os

--- a/tests/eval_files/trio240.py
+++ b/tests/eval_files/trio240.py
@@ -1,3 +1,4 @@
+# type: ignore
 import os.path
 from os.path import isfile, normpath, relpath
 

--- a/tests/eval_files/trio900.py
+++ b/tests/eval_files/trio900.py
@@ -1,3 +1,4 @@
+# type: ignore
 # ARG --no-checkpoint-warning-decorator=asynccontextmanager,other_context_manager
 
 

--- a/tests/eval_files/trio910.py
+++ b/tests/eval_files/trio910.py
@@ -1,3 +1,4 @@
+# type: ignore
 import typing
 from typing import Any, overload
 

--- a/tests/eval_files/trio911.py
+++ b/tests/eval_files/trio911.py
@@ -1,3 +1,4 @@
+# type: ignore
 from typing import Any
 
 import trio

--- a/tests/eval_files/trio_anyio.py
+++ b/tests/eval_files/trio_anyio.py
@@ -1,3 +1,4 @@
+# type: ignore
 # ARG --enable-visitor-codes-regex=(TRIO220)
 # NOANYIO
 import trio  # isort: skip

--- a/tests/test_flake8_trio.py
+++ b/tests/test_flake8_trio.py
@@ -538,7 +538,7 @@ select = TRIO220
         "[anyio|trio]",
     )
     err_file = str(Path(__file__).parent / "eval_files" / "anyio_trio.py")
-    expected = f"{err_file}:9:5: TRIO220 {err_msg}\n"
+    expected = f"{err_file}:10:5: TRIO220 {err_msg}\n"
     from flake8.main.cli import main
 
     main(


### PR DESCRIPTION
Stemming from #121 

rewriting nursery detection to use type tracking - affecting TRIO105&TRIO113

Much of the diff is due to renaming `eval_files/trio113.py` to `eval_files/trio113_trio.py` with very minor changes, and having checks that aren't trio-specific in `eval_files/trio113.py`

I've realized that typing the eval files is often quite handy, and also to check pyright/mypy support for whatever check I'm writing. So I modified the config to longer blanket exclude eval_files, and added `type: ignore` at the top of all files except the ones I directly worked on in this one. Might gradually remove some of the other ones too.
Likewise got a couple `# mypy: disable-error-code` since I (still) am running that in my editor. It raises a lot more warnings than pyright, but most of the code in the repo passes it (without `strict`)