### PR TITLE
reimplement 91X in libcst

### DIFF
--- a/flake8_trio/visitors/visitor101.py
+++ b/flake8_trio/visitors/visitor101.py
@@ -5,10 +5,7 @@
 """
 from __future__ import annotations
 
-from typing import Any
-
-import libcst as cst
-import libcst.matchers as m
+from typing import TYPE_CHECKING, Any
 
 from .flake8triovisitor import Flake8TrioVisitor_cst
 from .helpers import (
@@ -17,6 +14,9 @@ from .helpers import (
     func_has_decorator,
     with_has_call,
 )
+
+if TYPE_CHECKING:
+    import libcst as cst
 
 
 @error_class_cst
@@ -45,12 +45,13 @@ class Visitor101(Flake8TrioVisitor_cst):
             and bool(with_has_call(node, "open_nursery", *cancel_scope_names))
         )
 
-    @m.leave(m.OneOf(m.With(), m.FunctionDef()))
-    def restore_state(
+    def leave_With(
         self, original_node: cst.BaseStatement, updated_node: cst.BaseStatement
     ) -> cst.BaseStatement:
-        self.set_state(self.outer.pop(original_node, {}))
+        self.restore_state(original_node)
         return updated_node
+
+    leave_FunctionDef = leave_With
 
     def visit_FunctionDef(self, node: cst.FunctionDef):
         self.save_state(node, "_yield_is_error", "_safe_decorator")

--- a/flake8_trio/visitors/visitor91x.py
+++ b/flake8_trio/visitors/visitor91x.py
@@ -7,37 +7,89 @@ each yield.
 
 from __future__ import annotations
 
-import ast
+from dataclasses import dataclass, field
 from typing import Any
 
+import libcst as cst
+import libcst.matchers as m
+from libcst.metadata import PositionProvider
+
 from ..base import Statement
-from .flake8triovisitor import Flake8TrioVisitor
+from .flake8triovisitor import Flake8TrioVisitor_cst
 from .helpers import (
+    cst_literal_eval,
     disabled_by_default,
-    error_class,
-    fnmatch_qualified_name,
-    has_decorator,
-    iter_guaranteed_once,
+    error_class_cst,
+    fnmatch_qualified_name_cst,
+    func_has_decorator,
+    iter_guaranteed_once_cst,
 )
 
+ARTIFICIAL_STATEMENT = Statement("artificial", -1)
 
-# used in 910/911
-def empty_body(body: list[ast.stmt]) -> bool:
+
+def func_empty_body(node: cst.FunctionDef) -> bool:
     # Does the function body consist solely of `pass`, `...`, and (doc)string literals?
-    return all(
-        isinstance(stmt, ast.Pass)
-        or (
-            isinstance(stmt, ast.Expr)
-            and isinstance(stmt.value, ast.Constant)
-            and (stmt.value.value is Ellipsis or isinstance(stmt.value.value, str))
-        )
-        for stmt in body
+    return m.matches(
+        node.body,
+        m.IndentedBlock(
+            body=[
+                m.ZeroOrMore(
+                    m.SimpleStatementLine(
+                        body=[
+                            m.ZeroOrMore(
+                                m.Pass() | m.Expr(m.Ellipsis() | m.SimpleString())
+                            )
+                        ]
+                    )
+                )
+            ]
+        ),
     )
 
 
-@error_class
+@dataclass
+class LoopState:
+    infinite_loop: bool = False
+    body_guaranteed_once: bool = False
+    has_break: bool = False
+
+    uncheckpointed_before_continue: set[Statement] = field(default_factory=set)
+    uncheckpointed_before_break: set[Statement] = field(default_factory=set)
+    artificial_errors: set[cst.Return | cst.FunctionDef | cst.Yield] = field(
+        default_factory=set
+    )
+
+    def copy(self):
+        return LoopState(
+            infinite_loop=self.infinite_loop,
+            body_guaranteed_once=self.body_guaranteed_once,
+            has_break=self.has_break,
+            uncheckpointed_before_continue=self.uncheckpointed_before_continue.copy(),
+            uncheckpointed_before_break=self.uncheckpointed_before_break.copy(),
+            artificial_errors=self.artificial_errors.copy(),
+        )
+
+
+@dataclass
+class TryState:
+    body_uncheckpointed_statements: set[Statement] = field(default_factory=set)
+    try_checkpoint: set[Statement] = field(default_factory=set)
+    except_uncheckpointed_statements: set[Statement] = field(default_factory=set)
+    added: set[Statement] = field(default_factory=set)
+
+    def copy(self):
+        return TryState(
+            body_uncheckpointed_statements=self.body_uncheckpointed_statements.copy(),
+            try_checkpoint=self.try_checkpoint.copy(),
+            except_uncheckpointed_statements=self.except_uncheckpointed_statements.copy(),
+            added=self.added.copy(),
+        )
+
+
+@error_class_cst
 @disabled_by_default
-class Visitor91X(Flake8TrioVisitor):
+class Visitor91X(Flake8TrioVisitor_cst):
     error_codes = {
         "TRIO910": (
             "{0} from async function with no guaranteed checkpoint or exception "
@@ -54,101 +106,172 @@ class Visitor91X(Flake8TrioVisitor):
         self.has_yield = False
         self.safe_decorator = False
         self.async_function = False
-
         self.uncheckpointed_statements: set[Statement] = set()
-        self.uncheckpointed_before_continue: set[Statement] = set()
-        self.uncheckpointed_before_break: set[Statement] = set()
 
-        self.default = self.get_state()
+        self.loop_state = LoopState()
+        self.try_state = TryState()
 
-    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef):
+    @property
+    def infinite_loop(self) -> bool:
+        return self.loop_state.infinite_loop
+
+    @infinite_loop.setter
+    def infinite_loop(self, value: bool):
+        self.loop_state.infinite_loop = value
+
+    @property
+    def body_guaranteed_once(self) -> bool:
+        return self.loop_state.body_guaranteed_once
+
+    @body_guaranteed_once.setter
+    def body_guaranteed_once(self, value: bool):
+        self.loop_state.body_guaranteed_once = value
+
+    @property
+    def has_break(self) -> bool:
+        return self.loop_state.has_break
+
+    @has_break.setter
+    def has_break(self, value: bool):
+        self.loop_state.has_break = value
+
+    @property
+    def uncheckpointed_before_continue(self) -> set[Statement]:
+        return self.loop_state.uncheckpointed_before_continue
+
+    @uncheckpointed_before_continue.setter
+    def uncheckpointed_before_continue(self, value: set[Statement]):
+        self.loop_state.uncheckpointed_before_continue = value
+
+    @property
+    def uncheckpointed_before_break(self) -> set[Statement]:
+        return self.loop_state.uncheckpointed_before_break
+
+    @uncheckpointed_before_break.setter
+    def uncheckpointed_before_break(self, value: set[Statement]):
+        self.loop_state.uncheckpointed_before_break = value
+
+    @property
+    def artificial_errors(self) -> set[cst.Return | cst.FunctionDef | cst.Yield]:
+        return self.loop_state.artificial_errors
+
+    @artificial_errors.setter
+    def artificial_errors(self, value: set[cst.Return | cst.FunctionDef | cst.Yield]):
+        self.loop_state.artificial_errors = value  # pragma: no cover
+
+    def visit_FunctionDef(self, node: cst.FunctionDef) -> None:
         # don't lint functions whose bodies solely consist of pass or ellipsis
-        if has_decorator(node, "overload", "fixture") or empty_body(node.body):
+        if func_has_decorator(node, "overload", "fixture") or func_empty_body(node):
             return
 
-        self.save_state(node)
-        self.set_state(self.default, copy=True)
+        self.save_state(
+            node,
+            "has_yield",
+            "safe_decorator",
+            "async_function",
+            "uncheckpointed_statements",
+            "loop_state",
+            "try_state",
+            copy=True,
+        )
+        self.uncheckpointed_statements = set()
+        self.has_yield = self.safe_decorator = False
+        self.loop_state = LoopState()
 
-        # disable checks in asynccontextmanagers by saying the function isn't async
-        self.async_function = not fnmatch_qualified_name(
-            node.decorator_list, *self.options.no_checkpoint_warning_decorators
+        self.async_function = (
+            node.asynchronous is not None
+            and not fnmatch_qualified_name_cst(
+                node.decorators, *self.options.no_checkpoint_warning_decorators
+            )
         )
         if not self.async_function:
             return
 
+        pos = self.get_metadata(PositionProvider, node).start
         self.uncheckpointed_statements = {
-            Statement("function definition", node.lineno, node.col_offset)
+            Statement("function definition", pos.line, pos.column)
         }
 
-        self.generic_visit(node)
-
-        self.check_function_exit(node)
+    def leave_FunctionDef(
+        self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef
+    ) -> cst.FunctionDef:
+        if self.async_function:
+            # updated_node does not have a Position, so we must send original_node
+            self.check_function_exit(original_node)
+        self.restore_state(original_node)
+        return updated_node
 
     # error if function exits or returns with uncheckpointed statements
-    def check_function_exit(self, node: ast.Return | ast.AsyncFunctionDef):
+    def check_function_exit(self, node: cst.Return | cst.FunctionDef):
         for statement in self.uncheckpointed_statements:
-            self.error(
-                node,
-                "return" if isinstance(node, ast.Return) else "exit",
-                statement,
-                error_code="TRIO911" if self.has_yield else "TRIO910",
-            )
+            self.error_91x(node, statement)
 
-    def visit_Return(self, node: ast.Return):
+    def leave_Return(
+        self, original_node: cst.Return, updated_node: cst.Return
+    ) -> cst.Return:
         if not self.async_function:
-            return
-        self.generic_visit(node)
-        self.check_function_exit(node)
-
+            return updated_node
+        self.check_function_exit(original_node)
         # avoid duplicate error messages
         self.uncheckpointed_statements = set()
 
-    # disregard checkpoints in nested function definitions
-    def visit_FunctionDef(self, node: ast.FunctionDef):
-        self.save_state(node)
-        self.set_state(self.default, copy=True)
+        return updated_node
 
-    # checkpoint functions
-    def visit_Await(self, node: ast.Await | ast.Raise):
+    def error_91x(
+        self, node: cst.Return | cst.FunctionDef | cst.Yield, statement: Statement
+    ):
+        if statement == ARTIFICIAL_STATEMENT:
+            self.loop_state.artificial_errors.add(node)
+            return
+        if isinstance(node, cst.FunctionDef):
+            msg = "exit"
+        else:
+            msg = node.__class__.__name__.lower()
+
+        self.error(
+            node,
+            msg,
+            statement,
+            error_code="TRIO911" if self.has_yield else "TRIO910",
+        )
+
+    def leave_Await(
+        self, original_node: cst.Await, updated_node: cst.Await
+    ) -> cst.Await:
         # the expression being awaited is not checkpointed
         # so only set checkpoint after the await node
-        self.generic_visit(node)
 
         # all nodes are now checkpointed
         self.uncheckpointed_statements = set()
+        return updated_node
 
     # raising exception means we don't need to checkpoint so we can treat it as one
-    visit_Raise = visit_Await
+    # can't use TypeVar due to libcst's built-in type checking not supporting it
+    leave_Raise = leave_Await  # type: ignore
 
     # Async context managers can reasonably checkpoint on either or both of entry and
     # exit.  Given that we can't tell which, we assume "both" to avoid raising a
     # missing-checkpoint warning when there might in fact be one (i.e. a false alarm).
-    def visit_AsyncWith(self, node: ast.AsyncWith):
-        self.visit_nodes(node.items)
+    def visit_With_body(self, node: cst.With):
+        if getattr(node, "asynchronous", None):
+            self.uncheckpointed_statements = set()
 
-        self.uncheckpointed_statements = set()
-        self.visit_nodes(node.body)
-
-        self.uncheckpointed_statements = set()
+    leave_With_body = visit_With_body
 
     # error if no checkpoint since earlier yield or function entry
-    def visit_Yield(self, node: ast.Yield):
+    def leave_Yield(
+        self, original_node: cst.Yield, updated_node: cst.Yield
+    ) -> cst.Yield:
         if not self.async_function:
-            return
+            return updated_node
         self.has_yield = True
-        self.generic_visit(node)
         for statement in self.uncheckpointed_statements:
-            self.error(
-                node,
-                "yield",
-                statement,
-                error_code="TRIO911",
-            )
+            self.error_91x(original_node, statement)
 
         # mark as requiring checkpoint after
-        self.uncheckpointed_statements = {
-            Statement("yield", node.lineno, node.col_offset)
-        }
+        pos = self.get_metadata(PositionProvider, original_node).start
+        self.uncheckpointed_statements = {Statement("yield", pos.line, pos.column)}
+        return updated_node
 
     # valid checkpoint if there's valid checkpoints (or raise) in:
     # (try or else) and all excepts, or in finally
@@ -156,46 +279,59 @@ class Visitor91X(Flake8TrioVisitor):
     # try can jump into any except or into the finally* at any point during it's
     # execution so we need to make sure except & finally can handle worst-case
     # * unless there's a bare except / except BaseException - not implemented.
-    def visit_Try(self, node: ast.Try):
+    def visit_Try(self, node: cst.Try):
         if not self.async_function:
             return
+        self.save_state(node, "try_state")
         # except & finally guaranteed to enter with checkpoint if checkpointed
         # before try and no yield in try body.
-        body_uncheckpointed_statements = self.uncheckpointed_statements.copy()
-        for inner_node in self.walk(*node.body):
-            if isinstance(inner_node, ast.Yield):
-                body_uncheckpointed_statements.add(
-                    Statement("yield", inner_node.lineno, inner_node.col_offset)
-                )
+        self.try_state.body_uncheckpointed_statements = (
+            self.uncheckpointed_statements.copy()
+        )
+        for inner_node in m.findall(node.body, m.Yield()):
+            pos = self.get_metadata(PositionProvider, inner_node).start
+            self.try_state.body_uncheckpointed_statements.add(
+                Statement("yield", pos.line, pos.column)
+            )
 
-        # check try body
-        self.visit_nodes(node.body)
-
+    def leave_Try_body(self, node: cst.Try):
         # save state at end of try for entering else
-        try_checkpoint = self.uncheckpointed_statements
+        self.try_state.try_checkpoint = self.uncheckpointed_statements
 
         # check that all except handlers checkpoint (await or most likely raise)
-        except_uncheckpointed_statements: set[Statement] = set()
+        self.try_state.except_uncheckpointed_statements = set()
 
-        for handler in node.handlers:
-            # enter with worst case of try
-            self.uncheckpointed_statements = body_uncheckpointed_statements.copy()
+    def visit_ExceptHandler(self, node: cst.ExceptHandler):
+        # enter with worst case of try
+        self.uncheckpointed_statements = (
+            self.try_state.body_uncheckpointed_statements.copy()
+        )
 
-            self.visit_nodes(handler)
+    def leave_ExceptHandler(
+        self, original_node: cst.ExceptHandler, updated_node: cst.ExceptHandler
+    ) -> cst.ExceptHandler:
+        self.try_state.except_uncheckpointed_statements.update(
+            self.uncheckpointed_statements
+        )
+        return updated_node
 
-            except_uncheckpointed_statements.update(self.uncheckpointed_statements)
-
+    def visit_Try_orelse(self, node: cst.Try):
         # check else
         # if else runs it's after all of try, so restore state to back then
-        self.uncheckpointed_statements = try_checkpoint
-        self.visit_nodes(node.orelse)
+        self.uncheckpointed_statements = self.try_state.try_checkpoint
 
+    def leave_Try_orelse(self, node: cst.Try):
         # checkpoint if else checkpoints, and all excepts checkpoint
-        self.uncheckpointed_statements.update(except_uncheckpointed_statements)
+        self.uncheckpointed_statements.update(
+            self.try_state.except_uncheckpointed_statements
+        )
 
+    def visit_Try_finalbody(self, node: cst.Try):
         if node.finalbody:
-            added = body_uncheckpointed_statements.difference(
-                self.uncheckpointed_statements
+            self.try_state.added = (
+                self.try_state.body_uncheckpointed_statements.difference(
+                    self.uncheckpointed_statements
+                )
             )
             # if there's no bare except or except BaseException, we can jump into
             # finally from any point in try. But the exception will be reraised after
@@ -204,123 +340,154 @@ class Visitor91X(Flake8TrioVisitor):
             # very bad)
             if not any(
                 h.type is None
-                or (isinstance(h.type, ast.Name) and h.type.id == "BaseException")
+                or (isinstance(h.type, cst.Name) and h.type.value == "BaseException")
                 for h in node.handlers
             ):
-                self.uncheckpointed_statements.update(added)
+                self.uncheckpointed_statements.update(self.try_state.added)
 
-            self.visit_nodes(node.finalbody)
-            self.uncheckpointed_statements.difference_update(added)
+    def leave_Try_finalbody(self, node: cst.Try):
+        if node.finalbody:
+            self.uncheckpointed_statements.difference_update(self.try_state.added)
 
-    # valid checkpoint if both body and orelse checkpoint
-    def visit_If(self, node: ast.If | ast.IfExp):
+    def leave_Try(self, original_node: cst.Try, updated_node: cst.Try) -> cst.Try:
+        self.restore_state(original_node)
+        return updated_node
+
+    def leave_If_test(self, node: cst.If | cst.IfExp) -> None:
         if not self.async_function:
             return
-        # visit condition
-        self.visit_nodes(node.test)
-        outer = self.uncheckpointed_statements.copy()
+        self.save_state(node, "uncheckpointed_statements", copy=True)
 
-        # visit body
-        self.visit_nodes(node.body)
-        body_outer = self.uncheckpointed_statements
+    def leave_If_body(self, node: cst.If | cst.IfExp) -> None:
+        if not self.async_function:
+            return
 
-        # reset to after condition and visit orelse
-        self.uncheckpointed_statements = outer
-        self.visit_nodes(node.orelse)
+        # restore state to after test, saving current state instead
+        (
+            self.uncheckpointed_statements,
+            self.outer[node]["uncheckpointed_statements"],
+        ) = (
+            self.outer[node]["uncheckpointed_statements"],
+            self.uncheckpointed_statements,
+        )
 
-        # union of both branches is the new set of unhandled entries
-        self.uncheckpointed_statements.update(body_outer)
+    def leave_If(self, original_node: cst.If, updated_node: cst.If) -> cst.If:
+        if self.async_function:
+            # merge current state with post-body state
+            self.uncheckpointed_statements.update(
+                self.outer[original_node]["uncheckpointed_statements"]
+            )
+        return updated_node
 
-    # inline if
-    visit_IfExp = visit_If
+    # libcst calls attributes in the order they appear in the code, so we manually
+    # rejig the order here
+    def visit_IfExp(self, node: cst.IfExp) -> bool:
+        _ = node.test.visit(self)
+        self.leave_If_test(node)
+        _ = node.body.visit(self)
+        self.leave_If_body(node)
+        _ = node.orelse.visit(self)
+        self.leave_If(node, node)  # type: ignore
+        return False
+
+    def visit_While(self, node: cst.While | cst.For):
+        self.save_state(
+            node,
+            "loop_state",
+            copy=True,
+        )
+        self.loop_state = LoopState()
+        self.infinite_loop = self.body_guaranteed_once = False
 
     # Check for yields w/o checkpoint in between due to entering loop body the first time,
     # after completing all of loop body, and after any continues.
     # yield in else have same requirement
     # state after the loop same as above, and in addition the state at any break
-    def visit_loop(self, node: ast.While | ast.For | ast.AsyncFor):
+    def visit_While_test(self, node: cst.While):
+        # save state in case of nested loops
+        # ugly workaround since cst doesn't have literal_eval
+        if cst_literal_eval(node.test):
+            self.infinite_loop = self.body_guaranteed_once = True
+
+    def visit_For_iter(self, node: cst.For):
+        self.body_guaranteed_once = iter_guaranteed_once_cst(node.iter)
+
+    def visit_While_body(self, node: cst.While | cst.For):
         if not self.async_function:
             return
-        # visit condition
 
-        # the following block is duplicated in Visitor103_104
-        infinite_loop = False
-        if isinstance(node, ast.While):
-            try:
-                infinite_loop = body_guaranteed_once = bool(ast.literal_eval(node.test))
-            except Exception:  # noqa: PIE786
-                body_guaranteed_once = False
-            self.visit_nodes(node.test)
-        else:
-            self.visit_nodes(node.target)
-            self.visit_nodes(node.iter)
-            body_guaranteed_once = iter_guaranteed_once(node.iter)
-
-        # save state in case of nested loops
-        outer = self.get_state(
-            "uncheckpointed_before_continue",
-            "uncheckpointed_before_break",
-            "suppress_errors",
+        self.save_state(
+            node,
+            "uncheckpointed_statements",
         )
 
+        # inject an artificial uncheckpointed statement that won't raise an error,
+        # but will be marked if an error would be generated. We can then generate
+        # appropriate errors if the loop doesn't checkpoint
+
+        if getattr(node, "asynchronous", None):
+            self.uncheckpointed_statements = set()
+        else:
+            self.uncheckpointed_statements = {ARTIFICIAL_STATEMENT}
+
         self.uncheckpointed_before_continue = set()
-
-        # AsyncFor guaranteed checkpoint at every iteration
-        if isinstance(node, ast.AsyncFor):
-            self.uncheckpointed_statements = set()
-
-        pre_body_uncheckpointed_statements = self.uncheckpointed_statements
-
-        # check for all possible uncheckpointed statements before entering start of loop
-        # due to `continue` or multiple iterations
-        if not isinstance(node, ast.AsyncFor):
-            # reset uncheckpointed_statements to not clear it if awaited
-            self.uncheckpointed_statements = set()
-
-            # avoid duplicate errors
-            self.suppress_errors = True
-
-            # set self.uncheckpointed_before_continue and uncheckpointed at end of loop
-            self.visit_nodes(node.body)
-
-            self.suppress_errors = outer["suppress_errors"]
-
-            self.uncheckpointed_statements.update(self.uncheckpointed_before_continue)
-
-        # add uncheckpointed on first iter
-        self.uncheckpointed_statements.update(pre_body_uncheckpointed_statements)
-
-        # visit body
         self.uncheckpointed_before_break = set()
-        self.visit_nodes(node.body)
+
+    visit_For_body = visit_While_body
+
+    def leave_While_body(self, node: cst.While | cst.For):
+        if not self.async_function:
+            return
+        # if there's errors due to the artificial statement
+        # raise a real error for each statement in outer[uncheckpointed_statements],
+        # uncheckpointed_before_continue, and uncheckpointed_before_break
+        new_uncheckpointed_statements = (
+            self.outer[node]["uncheckpointed_statements"]
+            | self.uncheckpointed_statements
+        )
+        for err_node in self.artificial_errors:
+            for stmt in (
+                new_uncheckpointed_statements | self.uncheckpointed_before_continue
+            ):
+                self.error_91x(err_node, stmt)
+
+        # replace artificial in break with prebody uncheckpointed statements
+        for stmts in (
+            self.uncheckpointed_before_continue,
+            self.uncheckpointed_before_break,
+            self.uncheckpointed_statements,
+        ):
+            if ARTIFICIAL_STATEMENT in stmts:
+                stmts.remove(ARTIFICIAL_STATEMENT)
+                stmts.update(self.outer[node]["uncheckpointed_statements"])
 
         # AsyncFor guarantees checkpoint on running out of iterable
         # so reset checkpoint state at end of loop. (but not state at break)
-        if isinstance(node, ast.AsyncFor):
+        if getattr(node, "asynchronous", None):
             self.uncheckpointed_statements = set()
         else:
             # enter orelse with worst case:
             # loop body might execute fully before entering orelse
             # (current state of self.uncheckpointed_statements)
             # or not at all
-            if not body_guaranteed_once:
+            if not self.body_guaranteed_once:
                 self.uncheckpointed_statements.update(
-                    pre_body_uncheckpointed_statements
+                    self.outer[node]["uncheckpointed_statements"]
                 )
             # or at a continue, unless it's an infinite loop
-            if not infinite_loop:
+            if not self.infinite_loop:
                 self.uncheckpointed_statements.update(
                     self.uncheckpointed_before_continue
                 )
 
-        # visit orelse
-        self.visit_nodes(node.orelse)
+    leave_For_body = leave_While_body
 
+    def leave_While_orelse(self, node: cst.While | cst.For):
+        if not self.async_function:
+            return
         # if this is an infinite loop, with no break in it, don't raise
         # alarms about the state after it.
-        if infinite_loop and not any(
-            isinstance(n, ast.Break) for n in self.walk(*node.body)
-        ):
+        if self.infinite_loop and not self.has_break:
             self.uncheckpointed_statements = set()
         else:
             # We may exit from:
@@ -329,37 +496,33 @@ class Visitor91X(Flake8TrioVisitor):
             self.uncheckpointed_statements.update(self.uncheckpointed_before_break)
 
         # reset break & continue in case of nested loops
-        self.set_state(outer)
+        self.outer[node]["uncheckpointed_statements"] = self.uncheckpointed_statements
+        self.restore_state(node)
 
-    visit_While = visit_loop
-    visit_For = visit_loop
-    visit_AsyncFor = visit_loop
+    leave_For_orelse = leave_While_orelse
 
     # save state in case of continue/break at a point not guaranteed to checkpoint
-    def visit_Continue(self, node: ast.Continue):
+    def visit_Continue(self, node: cst.Continue):
         if not self.async_function:
             return
         self.uncheckpointed_before_continue.update(self.uncheckpointed_statements)
 
-    def visit_Break(self, node: ast.Break):
+    def visit_Break(self, node: cst.Break):
+        self.has_break = True
         if not self.async_function:
             return
         self.uncheckpointed_before_break.update(self.uncheckpointed_statements)
 
     # first node in a condition is always evaluated, but may shortcut at any point
     # after that so we track worst-case checkpoint (i.e. after yield)
-    def visit_BoolOp(self, node: ast.BoolOp):
+    def visit_BooleanOperation_right(self, node: cst.BooleanOperation):
         if not self.async_function:
             return
-        self.visit(node.op)
+        self.save_state(node, "uncheckpointed_statements", copy=True)
 
-        # first value always evaluated
-        self.visit(node.values[0])
-
-        worst_case_shortcut = self.uncheckpointed_statements.copy()
-
-        for value in node.values[1:]:
-            self.visit(value)
-            worst_case_shortcut.update(self.uncheckpointed_statements)
-
-        self.uncheckpointed_statements = worst_case_shortcut
+    def leave_BooleanOperation_right(self, node: cst.BooleanOperation):
+        if not self.async_function:
+            return
+        self.uncheckpointed_statements.update(
+            self.outer[node]["uncheckpointed_statements"]
+        )

--- a/tests/eval_files/trio100.py
+++ b/tests/eval_files/trio100.py
@@ -40,8 +40,13 @@ async def function_name():
     async with trio.fail_after(10):
         async with send_channel:
             pass
+
     async with trio.fail_after(10):
         async for _ in receive_channel:
+            pass
+
+    async with trio.fail_after(10):  # error: 15, "trio", "fail_after"
+        for _ in receive_channel:
             pass
 
     # fix missed alarm when function is defined inside the with scope

--- a/tests/eval_files/trio103.py
+++ b/tests/eval_files/trio103.py
@@ -228,6 +228,54 @@ except BaseException:  # TRIO103_trio: 7, "BaseException"
 
 try:
     ...
+except BaseException:  # TRIO103_trio: 7, "BaseException"
+    for i in foo():
+        raise
+
+try:
+    ...
+except BaseException:
+    for i in (*(), *(1, 2),):
+        raise
+
+try:
+    ...
+except BaseException:
+    for ii in {**{}, **{1: 2}}:
+        raise
+
+try:
+    ...
+except BaseException:
+    for i in range(3):
+        raise
+
+try:
+    ...
+except BaseException:  # TRIO103_trio: 7, "BaseException"
+    for i in range(foo()):
+        raise
+
+try:
+    ...
+except BaseException:  # TRIO103_trio: 7, "BaseException"
+    for i in []:
+        raise
+
+try:
+    ...
+except BaseException:  # TRIO103_trio: 7, "BaseException"
+    for i in {}:
+        raise
+
+try:
+    ...
+except BaseException:
+    for i in {1: 2}:
+        raise
+
+try:
+    ...
 except BaseException:
     while True:
         raise

--- a/tests/eval_files/trio910.py
+++ b/tests/eval_files/trio910.py
@@ -12,6 +12,7 @@ def __() -> Any:
 
 
 # ARG --enable-visitor-codes-regex=(TRIO910)|(TRIO911)
+# ARG --no-checkpoint-warning-decorator=custom_disabled_decorator
 
 
 # function whose body solely consists of pass, ellipsis, or string constants is safe
@@ -510,6 +511,16 @@ async def foo_test2():
     print("...")
 
 
+@custom_disabled_decorator
+async def foo_ARG_test():
+    print("...")
+
+
+@custom_disabled_decorator()
+async def foo_ARG_test2():
+    print("...")
+
+
 @pytest.fixture
 async def foo_test_return():
     return
@@ -518,3 +529,12 @@ async def foo_test_return():
 @pytest.fixture()
 async def foo_test_return2():
     return
+
+
+async def foo_comprehension_1():
+    [... for x in range(10) if await foo()]
+
+
+# should error
+async def foo_comprehension_2():
+    [await foo() for x in range(10) if foo()]


### PR DESCRIPTION
This one is *chonky*
I might go over it tomorrow and add review comments to help reviewing it. Although there's not really much to do other than grind through it - and running it on existing code, I wouldn't be shocked if there's crashes or bugs that didn't exist before, so maybe do that before releasing.

I generally optimized for minimizing the diff, rather than writing the best / most logical code - might leave that for a second commit, or do it when implementing autofix. Esp any `isinstance`s should generally not be there when working against libcst.

I rewrote the loop checker to not require two passes, by injecting a fake statement and doing some fancy logic. Quite happy I came up with this solution, much better than the previous super messy one.
Removing redundant checkpoints might be more doable with this approach as well.
Having to access metadata to get the linenos of nodes is quite ugly, with the redundant checkpoint I'll be looking to store nodes instead of `Statement`s in `uncheckpointed_statements`

test_910_permutations is now *extremely* slow, previously being so fast I never noticed it, but now it takes *50 seconds* on my machine. I did some rudimentary timing, and the `parse_module` call took 5 of the seconds, and plugin.run() taking 45 seconds. Now that is across ~4000 calls, so nothing too crazy, but I'll probably put it behind `--runfuzz` if I don't find anything responsible for the slowdown. 91X currently doesn't use any decorator markers, so changing it to be a simple transformer might do wonders.

A few changes in eval_files:
1. realized that comprehensions aren't handled, added regression tests.
2. I think the nested error test ... was wrong? I don't see why that should give two errors per line.
3. multiple yields in a single boolop is no longer handled as before. I maybe should've just done `fmt: off` instead of fighting over and over with black/shed