### PR TITLE
Now able to run as a standalone module or shell program, with limited functionality

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,6 @@ repos:
           - flake8-bugbear
           - flake8-comprehensions
           - flake8-2020
-          - flake8-bandit
           - flake8-builtins
           - flake8-bugbear
           - flake8-comprehensions

--- a/flake8_trio/__main__.py
+++ b/flake8_trio/__main__.py
@@ -1,0 +1,4 @@
+"""Entry file when executed with `python -m`."""
+from . import main
+
+main()

--- a/flake8_trio/base.py
+++ b/flake8_trio/base.py
@@ -32,11 +32,14 @@ class Error:
         self.message = message
         self.args = args
 
+    def format_message(self):
+        return f"{self.code} " + self.message.format(*self.args)
+
     # for yielding to flake8
     def __iter__(self):
         yield self.line
         yield self.col
-        yield f"{self.code} " + self.message.format(*self.args)
+        yield self.format_message()
         # We are no longer yielding `type(Plugin)` since that's quite tricky to do
         # without circular imports, and afaik flake8 doesn't care anymore.
         yield None
@@ -55,3 +58,7 @@ class Error:
     def __repr__(self) -> str:  # pragma: no cover
         trailer = "".join(f", {x!r}" for x in self.args)
         return f"<{self.code} error at {self.line}:{self.col}{trailer}>"
+
+    def __str__(self) -> str:
+        # flake8 adds 1 to the yielded column from `__iter__`, so we do the same here
+        return f"{self.line}:{self.col+1}: {self.format_message()}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.pyright]
 strict = ["*.py", "tests/*.py", "flake8_trio/**/*.py"]
 exclude = ["**/node_modules", "**/__pycache__", "**/.*"]
-reportUnusedCallResult=true
+reportUnusedCallResult=false
 reportUninitializedInstanceVariable=true
 reportPropertyTypeMismatch=true
 reportMissingSuperCall=true

--- a/setup.py
+++ b/setup.py
@@ -50,5 +50,6 @@ setup(
     long_description_content_type="text/markdown",
     entry_points={
         "flake8.extension": ["TRI = flake8_trio:Plugin"],
+        "console_scripts": ["flake8_trio=flake8_trio:main"],
     },
 )

--- a/tests/test_config_and_args.py
+++ b/tests/test_config_and_args.py
@@ -1,0 +1,191 @@
+"""Various tests for testing argument and config parsing."""
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from flake8_trio import Plugin
+
+from .test_flake8_trio import initialize_options
+
+
+def _common_error_setup(tmp_path: Path) -> str:
+    assert tmp_path.joinpath("example.py").write_text(
+        """import trio
+with trio.move_on_after(10):
+    ...
+"""
+    )
+    return (
+        "./example.py:2:6: TRIO100 trio.move_on_after context contains no checkpoints,"
+        " remove the context or add `await trio.lowlevel.checkpoint()`.\n"
+    )
+
+
+def test_run_flake8_trio(tmp_path: Path):
+    err_msg = _common_error_setup(tmp_path)
+    res = subprocess.run(
+        [
+            "flake8_trio",
+            "./example.py",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+    )
+    assert not res.stderr
+    assert res.stdout == err_msg.encode("ascii")
+
+
+def test_run_in_git_repo(tmp_path: Path):
+    err_msg = _common_error_setup(tmp_path)
+    assert subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True)
+    assert subprocess.run(["git", "add", "example.py"], cwd=tmp_path)
+    res = subprocess.run(
+        [
+            "flake8_trio",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+    )
+    assert not res.stderr
+    assert res.stdout == err_msg.encode("ascii")
+
+
+def test_run_no_git_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", [tmp_path / "flake8_trio"])
+    with pytest.raises(SystemExit):
+        from flake8_trio import __main__  # noqa
+    out, err = capsys.readouterr()
+    assert out == "Doesn't seem to be a git repo; pass filenames to format.\n"
+    assert not err
+
+
+def test_114_raises_on_invalid_parameter(capsys: pytest.CaptureFixture[str]):
+    plugin = Plugin(ast.AST(), [])
+    # flake8 will reraise ArgumentError as SystemExit
+    for arg in "blah.foo", "foo*", "*":
+        with pytest.raises(SystemExit):
+            initialize_options(plugin, args=[f"--startable-in-context-manager={arg}"])
+        out, err = capsys.readouterr()
+        assert not out
+        assert f"{arg!r} is not a valid method identifier" in err
+
+
+def test_200_options(capsys: pytest.CaptureFixture[str]):
+    plugin = Plugin(ast.AST(), [])
+    for i, arg in (0, "foo"), (2, "foo->->bar"), (2, "foo->bar->fee"):
+        with pytest.raises(SystemExit):
+            initialize_options(plugin, args=[f"--trio200-blocking-calls={arg}"])
+        out, err = capsys.readouterr()
+        assert not out, out
+        assert all(word in err for word in (str(i), arg, "->"))
+
+
+def test_anyio_from_config(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    assert tmp_path.joinpath(".flake8").write_text(
+        """
+[flake8]
+anyio = True
+select = TRIO220
+"""
+    )
+
+    from flake8_trio.visitors.visitor2xx import Visitor22X
+
+    err_msg = Visitor22X.error_codes["TRIO220"].format(
+        "subprocess.Popen",
+        "[anyio|trio]",
+    )
+    err_file = str(Path(__file__).parent / "eval_files" / "anyio_trio.py")
+    expected = f"{err_file}:10:5: TRIO220 {err_msg}\n"
+    from flake8.main.cli import main
+
+    returnvalue = main(
+        argv=[
+            err_file,
+            "--append-config",
+            str(tmp_path / ".flake8"),
+        ]
+    )
+    assert returnvalue == 1
+    out, err = capsys.readouterr()
+    assert not err
+    assert expected == out
+
+
+def _test_trio200_from_config_common(tmp_path: Path) -> str:
+    assert tmp_path.joinpath(".flake8").write_text(
+        """
+[flake8]
+trio200-blocking-calls =
+  other -> async,
+  sync_fns.* -> the_async_equivalent,
+select = TRIO200
+"""
+    )
+    assert tmp_path.joinpath("example.py").write_text(
+        """
+import sync_fns
+
+async def foo():
+    sync_fns.takes_a_long_time()
+"""
+    )
+    return (
+        "./example.py:5:5: TRIO200 User-configured blocking sync call sync_fns.* "
+        "in async function, consider replacing with the_async_equivalent.\n"
+    )
+
+
+def test_200_from_config_flake8_internals(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    # abuse flake8 internals to avoid having to use subprocess
+    # which breaks breakpoints and hinders debugging
+    # TODO: fixture (?) to change working directory
+
+    err_msg = _test_trio200_from_config_common(tmp_path)
+    # replace ./ with tmp_path/
+    err_msg = str(tmp_path) + err_msg[1:]
+
+    from flake8.main.cli import main
+
+    returnvalue = main(
+        argv=[
+            str(tmp_path / "example.py"),
+            "--append-config",
+            str(tmp_path / ".flake8"),
+        ]
+    )
+    out, err = capsys.readouterr()
+    assert returnvalue == 1
+    assert not err
+    assert err_msg == out
+
+
+def test_200_from_config_subprocess(tmp_path: Path):
+    err_msg = _test_trio200_from_config_common(tmp_path)
+    res = subprocess.run(["flake8"], cwd=tmp_path, capture_output=True)
+    assert not res.stderr
+    assert res.stdout == err_msg.encode("ascii")
+
+
+def test_900_default_off(capsys: pytest.CaptureFixture[str]):
+    from flake8.main.cli import main
+
+    returnvalue = main(
+        argv=[
+            "tests/trio900.py",
+        ]
+    )
+    out, err = capsys.readouterr()
+    assert returnvalue == 1
+    assert not err
+    assert "TRIO900" not in out

--- a/tests/test_flake8_trio.py
+++ b/tests/test_flake8_trio.py
@@ -8,7 +8,6 @@ import itertools
 import os
 import re
 import site
-import subprocess  # noqa: S404
 import sys
 import tokenize
 import unittest
@@ -163,7 +162,7 @@ def _parse_eval_file(test: str, content: str) -> tuple[list[Error], list[str]]:
                 # Append a bunch of empty strings so string formatting gives garbage
                 # instead of throwing an exception
                 try:
-                    args = eval(  # noqa: S307
+                    args = eval(
                         f"[{err_args}]",
                         {
                             "lineno": lineno,
@@ -505,135 +504,9 @@ def test_910_permutations():
             assert not errors, "# false alarm:\n" + function_str
 
 
-def test_114_raises_on_invalid_parameter(capsys: pytest.CaptureFixture[str]):
-    plugin = Plugin(ast.AST(), [])
-    # flake8 will reraise ArgumentError as SystemExit
-    for arg in "blah.foo", "foo*", "*":
-        with pytest.raises(SystemExit):
-            initialize_options(plugin, args=[f"--startable-in-context-manager={arg}"])
-        out, err = capsys.readouterr()
-        assert not out
-        assert f"{arg!r} is not a valid method identifier" in err
-
-
-def test_200_options(capsys: pytest.CaptureFixture[str]):
-    plugin = Plugin(ast.AST(), [])
-    for i, arg in (0, "foo"), (2, "foo->->bar"), (2, "foo->bar->fee"):
-        with pytest.raises(SystemExit):
-            initialize_options(plugin, args=[f"--trio200-blocking-calls={arg}"])
-        out, err = capsys.readouterr()
-        assert not out, out
-        assert all(word in err for word in (str(i), arg, "->"))
-
-
-def test_anyio_from_config(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
-    assert tmp_path.joinpath(".flake8").write_text(
-        """
-[flake8]
-anyio = True
-select = TRIO220
-"""
-    )
-
-    from flake8_trio.visitors.visitor2xx import Visitor22X
-
-    err_msg = Visitor22X.error_codes["TRIO220"].format(
-        "subprocess.Popen",
-        "[anyio|trio]",
-    )
-    err_file = str(Path(__file__).parent / "eval_files" / "anyio_trio.py")
-    expected = f"{err_file}:10:5: TRIO220 {err_msg}\n"
-    from flake8.main.cli import main
-
-    returnvalue = main(
-        argv=[
-            err_file,
-            "--append-config",
-            str(tmp_path / ".flake8"),
-        ]
-    )
-    assert returnvalue == 1
-    out, err = capsys.readouterr()
-    assert not err
-    assert expected == out
-
-
-def _test_trio200_from_config_common(tmp_path: Path) -> str:
-    assert tmp_path.joinpath(".flake8").write_text(
-        """
-[flake8]
-trio200-blocking-calls =
-  other -> async,
-  sync_fns.* -> the_async_equivalent,
-select = TRIO200
-"""
-    )
-    assert tmp_path.joinpath("example.py").write_text(
-        """
-import sync_fns
-
-async def foo():
-    sync_fns.takes_a_long_time()
-"""
-    )
-    return (
-        "./example.py:5:5: TRIO200 User-configured blocking sync call sync_fns.* "
-        "in async function, consider replacing with the_async_equivalent.\n"
-    )
-
-
-def test_200_from_config_flake8_internals(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-):
-    # abuse flake8 internals to avoid having to use subprocess
-    # which breaks breakpoints and hinders debugging
-    # TODO: fixture (?) to change working directory
-
-    err_msg = _test_trio200_from_config_common(tmp_path)
-    # replace ./ with tmp_path/
-    err_msg = str(tmp_path) + err_msg[1:]
-
-    from flake8.main.cli import main
-
-    returnvalue = main(
-        argv=[
-            str(tmp_path / "example.py"),
-            "--append-config",
-            str(tmp_path / ".flake8"),
-        ]
-    )
-    out, err = capsys.readouterr()
-    assert returnvalue == 1
-    assert not err
-    assert err_msg == out
-
-
-def test_200_from_config_subprocess(tmp_path: Path):
-    err_msg = _test_trio200_from_config_common(tmp_path)
-    res = subprocess.run(  # noqa: S603,S607
-        ["flake8"], cwd=tmp_path, capture_output=True
-    )
-    assert not res.stderr
-    assert res.stdout == err_msg.encode("ascii")
-
-
-def test_900_default_off(capsys: pytest.CaptureFixture[str]):
-    from flake8.main.cli import main
-
-    returnvalue = main(
-        argv=[
-            "tests/trio900.py",
-        ]
-    )
-    out, err = capsys.readouterr()
-    assert returnvalue == 1
-    assert not err
-    assert "TRIO900" not in out
-
-
 # from https://docs.python.org/3/library/itertools.html#itertools-recipes
 def consume(iterator: Iterable[Any]):
-    deque(iterator, maxlen=0)  # pyright: reportUnusedCallResult=false
+    deque(iterator, maxlen=0)
 
 
 @pytest.mark.fuzz()


### PR DESCRIPTION
First steps towards having it run as a standalone program, which is required for autofixing.

* takes basic structure from shed, copying `_get_git_repo_root`.
* Add some magic to get argparsing to work both as standalone and as a plugin
* add `flake8_trio/__main__` to run as a module, and a `console_scripts` entry point
* moved out config testing from `test_flake8_trio`, and added a couple tests to test the above
  * crossing my fingers that git tests will magically work in the CI environment as well

Also:
* Remove `flake8-bandit` - running `git` directly is .. kinda sus https://flake8.codes/S607/ ; but if `shed` does it I'm not gonna bother, and I'm very much just disabling ~all errors bandit throws, so it's not really contributing anything.
* `reportUnusedCallResult` is frustrating, byebye~

Remaining steps:
* Color support - I was most of the way to replicating flake8's color printing, but once it got into testing/coverage and windows support I abandoned it and threw it out. For a later PR, if ever.
* Disable visitors with other ways than `--enable-visitor-codes-regex`
* pre-commit support
* read config
added these to OP in #124