### PR TITLE
implement autofix for TRIO100

### DIFF
--- a/flake8_trio/runner.py
+++ b/flake8_trio/runner.py
@@ -100,20 +100,20 @@ class Flake8TrioRunner(ast.NodeVisitor):
 
 
 class Flake8TrioRunner_cst:
-    def __init__(self, options: Namespace):
+    def __init__(self, options: Namespace, module: Module):
         super().__init__()
         self.state = SharedState(options)
         self.options = options
         self.visitors: tuple[Flake8TrioVisitor_cst, ...] = tuple(
             v(self.state) for v in ERROR_CLASSES_CST if self.selected(v.error_codes)
         )
+        self.module = module
 
-    def run(self, module: Module) -> Iterable[Error]:
+    def run(self) -> Iterable[Error]:
         if not self.visitors:
             return
-        wrapper = cst.MetadataWrapper(module)
         for v in self.visitors:
-            _ = wrapper.visit(v)
+            self.module = cst.MetadataWrapper(self.module).visit(v)
         yield from self.state.problems
 
     def selected(self, error_codes: dict[str, str]) -> bool:

--- a/flake8_trio/visitors/visitors.py
+++ b/flake8_trio/visitors/visitors.py
@@ -91,7 +91,7 @@ class Visitor112(Flake8TrioVisitor):
             nursery = get_matching_call(item.context_expr, "open_nursery")
 
             # `isinstance(..., ast.Call)` is done in get_matching_call
-            body_call = cast(ast.Call, node.body[0].value)
+            body_call = cast("ast.Call", node.body[0].value)
 
             if (
                 nursery is not None

--- a/tests/autofix_files/trio100.py
+++ b/tests/autofix_files/trio100.py
@@ -2,24 +2,24 @@
 
 import trio
 
-with trio.move_on_after(10):  # error: 5, "trio", "move_on_after"
-    ...
+# error: 5, "trio", "move_on_after"
+...
 
 
 async def function_name():
     # fmt: off
-    async with trio.fail_after(10): ...; ...; ...  # error: 15, "trio", "fail_after"
+    ...; ...; ...
     # fmt: on
-    async with trio.fail_after(10):  # error: 15, "trio", "fail_after"
-        ...
-    async with trio.fail_at(10):  # error: 15, "trio", "fail_at"
-        ...
-    async with trio.move_on_after(10):  # error: 15, "trio", "move_on_after"
-        ...
-    async with trio.move_on_at(10):  # error: 15, "trio", "move_on_at"
-        ...
-    async with trio.CancelScope(...):  # error: 15, "trio", "CancelScope"
-        ...
+    # error: 15, "trio", "fail_after"
+    ...
+    # error: 15, "trio", "fail_at"
+    ...
+    # error: 15, "trio", "move_on_after"
+    ...
+    # error: 15, "trio", "move_on_at"
+    ...
+    # error: 15, "trio", "CancelScope"
+    ...
 
     with trio.move_on_after(10):
         await trio.sleep(1)
@@ -36,8 +36,8 @@ async def function_name():
     with open("filename") as _:
         ...
 
-    with trio.fail_after(10):  # error: 9, "trio", "fail_after"
-        ...
+    # error: 9, "trio", "fail_after"
+    ...
 
     send_channel, receive_channel = trio.open_memory_channel(0)
     async with trio.fail_after(10):
@@ -48,22 +48,22 @@ async def function_name():
         async for _ in receive_channel:
             ...
 
-    async with trio.fail_after(10):  # error: 15, "trio", "fail_after"
-        for _ in receive_channel:
-            ...
+    # error: 15, "trio", "fail_after"
+    for _ in receive_channel:
+        ...
 
     # fix missed alarm when function is defined inside the with scope
-    with trio.move_on_after(10):  # error: 9, "trio", "move_on_after"
+    # error: 9, "trio", "move_on_after"
+
+    async def foo():
+        await trio.sleep(1)
+
+    # error: 9, "trio", "move_on_after"
+    if ...:
 
         async def foo():
-            await trio.sleep(1)
-
-    with trio.move_on_after(10):  # error: 9, "trio", "move_on_after"
-        if ...:
-
-            async def foo():
-                if ...:
-                    await trio.sleep(1)
+            if ...:
+                await trio.sleep(1)
 
     async with random_ignored_library.fail_after(10):
         ...

--- a/tests/autofix_files/trio100_simple_autofix.py
+++ b/tests/autofix_files/trio100_simple_autofix.py
@@ -1,0 +1,59 @@
+import trio
+
+# a
+# b
+# error: 5, "trio", "move_on_after"
+# c
+# d
+print(1)  # e
+# f
+# g
+print(2)  # h
+# i
+# j
+print(3)  # k
+# l
+# m
+pass
+# n
+
+# error: 5, "trio", "move_on_after"
+...
+
+
+# a
+# b
+# fmt: off
+...;...;...
+# fmt: on
+# c
+# d
+
+# Doesn't autofix With's with multiple withitems
+with (
+    trio.move_on_after(10),  # error: 4, "trio", "move_on_after"
+    open("") as f,
+):
+    ...
+
+
+# multiline with, despite only being one statement
+# a
+# b
+# c
+# error: 4, "trio", "move_on_after"
+# d
+# e
+# f
+# g
+# h
+# this comment is kept
+...
+
+# fmt: off
+# a
+# b
+# error: 4, "trio", "move_on_after"
+# c
+...; ...; ...
+# fmt: on

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,12 @@ def pytest_addoption(parser: pytest.Parser):
         "--runfuzz", action="store_true", default=False, help="run fuzz tests"
     )
     parser.addoption(
+        "--generate-autofix",
+        action="store_true",
+        default=False,
+        help="generate autofix file content",
+    )
+    parser.addoption(
         "--enable-visitor-codes-regex",
         default=".*",
         help="select error codes whose visitors to run.",
@@ -30,6 +36,11 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
     for item in items:
         if "fuzz" in item.keywords:
             item.add_marker(skip_fuzz)
+
+
+@pytest.fixture()
+def generate_autofix(request: pytest.FixtureRequest):
+    return request.config.getoption("generate_autofix")
 
 
 @pytest.fixture()

--- a/tests/eval_files/trio100_simple_autofix.py
+++ b/tests/eval_files/trio100_simple_autofix.py
@@ -1,0 +1,58 @@
+import trio
+
+# a
+# b
+with trio.move_on_after(10):  # error: 5, "trio", "move_on_after"
+    # c
+    # d
+    print(1)  # e
+    # f
+    # g
+    print(2)  # h
+    # i
+    # j
+    print(3)  # k
+    # l
+    # m
+# n
+
+with trio.move_on_after(10):  # error: 5, "trio", "move_on_after"
+    ...
+
+
+# a
+# b
+# fmt: off
+with trio.move_on_after(10): ...;...;... # error: 5, "trio", "move_on_after"
+# fmt: on
+# c
+# d
+
+# Doesn't autofix With's with multiple withitems
+with (
+    trio.move_on_after(10),  # error: 4, "trio", "move_on_after"
+    open("") as f,
+):
+    ...
+
+
+# multiline with, despite only being one statement
+with (  # a
+    # b
+    # c
+    trio.move_on_after(  # error: 4, "trio", "move_on_after"
+        # d
+        9999999999999999999999999999999999999999999999999999999  # e
+        # f
+    )  # g
+    # h
+):  # this comment is kept
+    ...
+
+# fmt: off
+with (  # a
+    # b
+    trio.move_on_after(10)  # error: 4, "trio", "move_on_after"
+    # c
+): ...; ...; ...
+# fmt: on

--- a/tests/test_config_and_args.py
+++ b/tests/test_config_and_args.py
@@ -63,8 +63,24 @@ def test_run_no_git_repo(
     with pytest.raises(SystemExit):
         from flake8_trio import __main__  # noqa
     out, err = capsys.readouterr()
-    assert out == "Doesn't seem to be a git repo; pass filenames to format.\n"
+    assert err == "Doesn't seem to be a git repo; pass filenames to format.\n"
+    assert not out
+
+
+def test_run_100_autofix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    err_msg = _common_error_setup(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        sys, "argv", [tmp_path / "flake8_trio", "--autofix", "./example.py"]
+    )
+    from flake8_trio import __main__  # noqa
+
+    out, err = capsys.readouterr()
+    assert out == err_msg
     assert not err
+    assert tmp_path.joinpath("example.py").read_text() == "import trio\n...\n"
 
 
 def test_114_raises_on_invalid_parameter(capsys: pytest.CaptureFixture[str]):

--- a/tox.ini
+++ b/tox.ini
@@ -48,9 +48,9 @@ exclude_lines =
 
 [flake8]
 max-line-length = 90
-extend-ignore = S101, D101, D102, D103, D105, D106, D107, TC006
+extend-ignore = S101, D101, D102, D103, D105, D106, D107
 extend-enable = TC10
-exclude = .*, tests/eval_files/*
+exclude = .*, tests/eval_files/*, tests/autofix_files/*
 per-file-ignores =
     flake8_trio/visitors/__init__.py: F401, E402
 # (E301, E302) black formats stub files without excessive blank lines


### PR DESCRIPTION
Before jumping on autofixing TRIO91X I decided to start with the simpler TRIO100.
Turns out I'd forgotten how messy it is to manipulate code and preserve whitespace, comments, lines, etc etc etc :upside_down_face: 

~~But I remember solving it in shed, so I can probably crib that from there and write some helper function.
Also remaining is actually changing the file on disk, and adding a flag.~~

~~shed/Black/isort is also back to being incredibly annoying, I'll have to figure out a better way of writing autofix files so they don't get fucked with as much as is done currently.~~