### PR TITLE
update pre-commit revs, flake8-typecheck now ignores stub files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,13 +5,13 @@ ci:
 
 repos:
 -   repo: https://github.com/Zac-HD/shed
-    rev: 0.10.9
+    rev: 2023.3.1
     hooks:
     -   id: shed
         args: ['--py39-plus']
 
 -   repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.293
+    rev: v1.1.298
     hooks:
     -   id: pyright
         entry: env PYRIGHT_PYTHON_FORCE_VERSION=latest pyright
@@ -26,7 +26,7 @@ repos:
           - anyio
 
 -   repo: https://github.com/codespell-project/codespell
-    rev: v2.2.2
+    rev: v2.2.3
     hooks:
     - id: codespell
       additional_dependencies:

--- a/tox.ini
+++ b/tox.ini
@@ -42,12 +42,10 @@ extend-enable = TC10
 exclude = .*, tests/eval_files/*
 per-file-ignores =
     flake8_trio/visitors/__init__.py: F401, E402
-# (TC002, TC003) We don't care about moving imports into type-checking blocks
-# see https://github.com/snok/flake8-type-checking/issues/152
 # (E301, E302) black formats stub files without excessive blank lines
 # (D) we don't care about docstrings in stub files
 # (Y021, Y048) pyright includes docstrings in generated files, so don't complain about them
-    *.pyi: TC002, TC003, D, E301, E302
+    *.pyi: D, E301, E302
 
 [coverage:report]
 exclude_lines =


### PR DESCRIPTION
I took the liberty of quickly writing a PR for https://github.com/snok/flake8-type-checking/issues/152 - so those `per-file-ignores` can now be removed ^^