### PR TITLE
add mypy to get warnings on unreachable code, fix/ignore various small typing errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,11 @@ repos:
       hooks:
           - id: isort
 
+    - repo: https://github.com/pre-commit/mirrors-mypy
+      rev: v1.1.1
+      hooks:
+          - id: mypy
+
     - repo: https://github.com/RobertCraigie/pyright-python
       rev: v1.1.298
       hooks:

--- a/flake8_trio/__init__.py
+++ b/flake8_trio/__init__.py
@@ -162,7 +162,7 @@ class Plugin:
             # Disable TRIO9xx calls by default
             option_manager.extend_default_ignore(default_disabled_error_codes)
             # add parameter to parse from flake8 config
-            add_argument = functools.partial(
+            add_argument = functools.partial(  # type: ignore
                 option_manager.add_option, parse_from_config=True
             )
         add_argument("--autofix", action="store_true", required=False)
@@ -207,7 +207,7 @@ class Plugin:
         )
         add_argument(
             "--enable-visitor-codes-regex",
-            type=re.compile,
+            type=re.compile,  # type: ignore[arg-type]
             default=".*",
             required=False,
             help=(

--- a/flake8_trio/visitors/helpers.py
+++ b/flake8_trio/visitors/helpers.py
@@ -44,8 +44,10 @@ def error_class_cst(error_class: type[T_CST]) -> type[T_CST]:
 
 
 def disabled_by_default(error_class: type[T_EITHER]) -> type[T_EITHER]:
-    assert error_class.error_codes
-    default_disabled_error_codes.extend(error_class.error_codes)
+    assert error_class.error_codes  # type: ignore[attr-defined]
+    default_disabled_error_codes.extend(
+        error_class.error_codes  # type: ignore[attr-defined]
+    )
     return error_class
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,13 @@ quiet = true
 skip_gitignore = true
 skip_glob = "tests/eval_files/*"
 
+[tool.mypy]
+check_untyped_defs = true
+disable_error_code = ["no-untyped-def", "misc", "no-untyped-call", "no-any-return"]
+strict = true
+warn_unreachable = true
+warn_unused_ignores = false
+
 [tool.pyright]
 exclude = ["**/node_modules", "**/__pycache__", "**/.*"]
 reportCallInDefaultInitializer = true

--- a/tests/eval_files/trio103.py
+++ b/tests/eval_files/trio103.py
@@ -48,9 +48,9 @@ except BaseException:  # TRIO103_trio: 7, "BaseException"
 try:
     ...
 except BaseException as e:  # TRIO103_trio: 7, "BaseException"
-    if True:
+    if ...:
         raise e
-    elif True:
+    elif ...:
         ...
     else:
         raise e
@@ -64,9 +64,9 @@ except BaseException:  # TRIO103_trio: 7, "BaseException"
 try:
     ...
 except BaseException:  # safe
-    if True:
+    if ...:
         raise
-    elif True:
+    elif ...:
         raise
     else:
         raise
@@ -121,7 +121,7 @@ try:
     ...
 except BaseException:
     raise
-    for _ in "":
+    for _ in "": # type: ignore[unreachable]
         if ...:
             break
         raise
@@ -241,7 +241,7 @@ except BaseException:
 try:
     ...
 except BaseException:
-    for ii in {**{}, **{1: 2}}:
+    for i in {**{}, **{1: 2}}: # type: ignore[arg-type]
         raise
 
 try:

--- a/tests/eval_files/trio104.py
+++ b/tests/eval_files/trio104.py
@@ -82,11 +82,12 @@ except ValueError as e:
     except BaseException:
         raise e  # error: 8
 
-# check for avoiding re-raise by returning from function
 def foo():
     if True:  # for code coverage
         return
 
+# check for avoiding re-raise by returning from function
+def foo2():
     try:
         ...
     except BaseException:  # TRIO103_trio: 11, "BaseException"
@@ -101,27 +102,29 @@ def foo():
         except ValueError:
             return  # error: 12
         else:
-            return  # error: 12
+            return  # type: ignore[unreachable] # error: 12
         finally:
             return  # error: 12
 
 
 # don't avoid re-raise with continue/break
-while True:
-    try:
-        ...
-    except BaseException:
-        if True:
-            continue  # error: 12
-        raise
+def foo3():
+    while True:
+        try:
+            ...
+        except BaseException:
+            if True:
+                continue  # error: 16
+            raise
 
-while True:
-    try:
-        ...
-    except BaseException:
-        if True:
-            break  # error: 12
-        raise
+def foo4():
+    while True:
+        try:
+            ...
+        except BaseException:
+            if True:
+                break  # error: 16
+            raise
 
 try:
     ...

--- a/tests/eval_files/trio105.py
+++ b/tests/eval_files/trio105.py
@@ -1,12 +1,35 @@
 # NOANYIO
 from typing import Any
+from collections.abc import Coroutine
 
 import trio
 
 par: Any = ...
+async_funpar: Coroutine[Any, Any, Any] = ...  # type: ignore
 
 
-async def foo():
+async def myasyncfun(task_status):
+    ...
+
+
+# calls that don't return
+async def inf1() -> None:
+    await trio.serve_listeners(par, par)
+
+
+async def inf2() -> None:
+    await trio.serve_ssl_over_tcp()
+
+
+async def inf3() -> None:
+    await trio.serve_tcp()
+
+
+async def inf4() -> None:
+    await trio.sleep_forever()
+
+
+async def foo() -> None:
     # not async
     trio.run(par)
 
@@ -19,75 +42,72 @@ async def foo():
     await trio.open_tcp_stream(par, par)
     await trio.open_unix_socket(par)
     await trio.run_process(par)
-    await trio.serve_listeners(par, par)
-    await trio.serve_ssl_over_tcp()
-    await trio.serve_tcp()
-    await trio.sleep()
-    await trio.sleep_forever()
-    await trio.sleep_until()
+    await trio.sleep(5)
+    await trio.sleep_until(5)
     await trio.lowlevel.cancel_shielded_checkpoint()
     await trio.lowlevel.checkpoint()
     await trio.lowlevel.checkpoint_if_cancelled()
-    await trio.lowlevel.open_process()
-    await trio.lowlevel.permanently_detach_coroutine_object()
-    await trio.lowlevel.reattach_detached_coroutine_object()
-    await trio.lowlevel.temporarily_detach_coroutine_object()
-    await trio.lowlevel.wait_readable()
-    await trio.lowlevel.wait_task_rescheduled()
-    await trio.lowlevel.wait_writable()
+    await trio.lowlevel.open_process(par)
+    await trio.lowlevel.permanently_detach_coroutine_object(par)
+    await trio.lowlevel.reattach_detached_coroutine_object(par, par)
+    await trio.lowlevel.temporarily_detach_coroutine_object(par)
+    await trio.lowlevel.wait_readable(par)
+    await trio.lowlevel.wait_task_rescheduled(par)
+    await trio.lowlevel.wait_writable(par)
 
     # all async functions
-    trio.aclose_forcefully()  # error: 4, "trio.aclose_forcefully", "function"
-    trio.open_file()  # error: 4, "trio.open_file", "function"
-    trio.open_ssl_over_tcp_listeners()  # error: 4, "trio.open_ssl_over_tcp_listeners", "function"
-    trio.open_ssl_over_tcp_stream()  # error: 4, "trio.open_ssl_over_tcp_stream", "function"
-    trio.open_tcp_listeners()  # error: 4, "trio.open_tcp_listeners", "function"
-    trio.open_tcp_stream()  # error: 4, "trio.open_tcp_stream", "function"
-    trio.open_unix_socket()  # error: 4, "trio.open_unix_socket", "function"
-    trio.run_process()  # error: 4, "trio.run_process", "function"
-    trio.serve_listeners()  # error: 4, "trio.serve_listeners", "function"
-    trio.serve_ssl_over_tcp()  # error: 4, "trio.serve_ssl_over_tcp", "function"
-    trio.serve_tcp()  # error: 4, "trio.serve_tcp", "function"
-    trio.sleep()  # error: 4, "trio.sleep", "function"
+    # fmt: off
+    trio.aclose_forcefully(par)  # error: 4, "trio.aclose_forcefully", "function"
+    trio.open_file(par)  # error: 4, "trio.open_file", "function"
+    trio.open_ssl_over_tcp_listeners(par, par)  # error: 4, "trio.open_ssl_over_tcp_listeners", "function"
+    trio.open_ssl_over_tcp_stream(par, par)  # error: 4, "trio.open_ssl_over_tcp_stream", "function"
+    trio.open_tcp_listeners(par)  # error: 4, "trio.open_tcp_listeners", "function"
+    trio.open_tcp_stream(par, par)  # error: 4, "trio.open_tcp_stream", "function"
+    trio.open_unix_socket(par)  # error: 4, "trio.open_unix_socket", "function"
+    trio.run_process(par)  # error: 4, "trio.run_process", "function"
+    trio.serve_listeners(par, par)  # error: 4, "trio.serve_listeners", "function"
+    trio.serve_ssl_over_tcp(par, par, par)  # error: 4, "trio.serve_ssl_over_tcp", "function"
+    trio.serve_tcp(par, par)  # error: 4, "trio.serve_tcp", "function"
+    trio.sleep(par)  # error: 4, "trio.sleep", "function"
     trio.sleep_forever()  # error: 4, "trio.sleep_forever", "function"
-    trio.sleep_until()  # error: 4, "trio.sleep_until", "function"
+    trio.sleep_until(par)  # error: 4, "trio.sleep_until", "function"
 
     # long lines, wheee
     trio.lowlevel.cancel_shielded_checkpoint()  # error: 4, "trio.lowlevel.cancel_shielded_checkpoint", "function"
     trio.lowlevel.checkpoint()  # error: 4, "trio.lowlevel.checkpoint", "function"
     trio.lowlevel.checkpoint_if_cancelled()  # error: 4, "trio.lowlevel.checkpoint_if_cancelled", "function"
     trio.lowlevel.open_process()  # error: 4, "trio.lowlevel.open_process", "function"
-    trio.lowlevel.permanently_detach_coroutine_object()  # error: 4, "trio.lowlevel.permanently_detach_coroutine_object", "function"
-    trio.lowlevel.reattach_detached_coroutine_object()  # error: 4, "trio.lowlevel.reattach_detached_coroutine_object", "function"
-    trio.lowlevel.temporarily_detach_coroutine_object()  # error: 4, "trio.lowlevel.temporarily_detach_coroutine_object", "function"
-    trio.lowlevel.wait_readable()  # error: 4, "trio.lowlevel.wait_readable", "function"
-    trio.lowlevel.wait_task_rescheduled()  # error: 4, "trio.lowlevel.wait_task_rescheduled", "function"
-    trio.lowlevel.wait_writable()  # error: 4, "trio.lowlevel.wait_writable", "function"
-
+    trio.lowlevel.permanently_detach_coroutine_object(par)  # error: 4, "trio.lowlevel.permanently_detach_coroutine_object", "function"
+    trio.lowlevel.reattach_detached_coroutine_object(par, par)  # error: 4, "trio.lowlevel.reattach_detached_coroutine_object", "function"
+    trio.lowlevel.temporarily_detach_coroutine_object(par)  # error: 4, "trio.lowlevel.temporarily_detach_coroutine_object", "function"
+    trio.lowlevel.wait_readable(par)  # error: 4, "trio.lowlevel.wait_readable", "function"
+    trio.lowlevel.wait_task_rescheduled(par)  # error: 4, "trio.lowlevel.wait_task_rescheduled", "function"
+    trio.lowlevel.wait_writable(par)  # error: 4, "trio.lowlevel.wait_writable", "function"
+    # fmt: on
     # safe
-    async with await trio.open_file() as f:
+    async with await trio.open_file(par) as f:
         pass
 
-    async with trio.open_file() as f:  # error: 15, "trio.open_file", "function"
+    async with trio.open_file(par) as f:  # error: 15, "trio.open_file", "function"
         pass
 
     # safe in theory, but deemed sufficiently poor style that parsing
     # it isn't supported
-    k = trio.open_file()  # error: 8, "trio.open_file", "function"
+    k = trio.open_file(par)  # error: 8, "trio.open_file", "function"
     await k
 
     # issue #56
-    nursery = trio.open_nursery()
-    await nursery.start()
-    await nursery.start_foo()
+    async with trio.open_nursery() as nursery:
+        await nursery.start(myasyncfun)
+        await nursery.start_foo()
 
-    nursery.start()  # error: 4, "trio.Nursery.start", "method"
-    None.start()  # type: ignore
-    nursery.start_soon()
-    nursery.start_foo()
+        nursery.start(myasyncfun)  # error: 8, "trio.Nursery.start", "method"
+        None.start()  # type: ignore
+        nursery.start_soon(par)
+        nursery.start_foo()
 
-    with trio.open_nursery() as booboo:
-        booboo.start()  # error: 8, "trio.Nursery.start", "method"
+        async with trio.open_nursery() as booboo:
+            booboo.start(myasyncfun)  # error: 12, "trio.Nursery.start", "method"
 
-    barbar: trio.Nursery = ...
-    barbar.start()  # error: 4, "trio.Nursery.start", "method"
+        barbar: trio.Nursery = ...
+        barbar.start(myasyncfun)  # error: 8, "trio.Nursery.start", "method"

--- a/tests/eval_files/trio910.py
+++ b/tests/eval_files/trio910.py
@@ -1,3 +1,4 @@
+# mypy: disable-error-code="unreachable"
 import typing
 from typing import Any, overload
 

--- a/tests/eval_files/trio911.py
+++ b/tests/eval_files/trio911.py
@@ -731,7 +731,7 @@ async def foo_loop_static():
         await foo()
     yield
 
-    for _ in {**{}, **{1: 2}}:
+    for _ in {**{}, **{1: 2}}:  # type: ignore[arg-type]
         await foo()
     yield
 
@@ -795,7 +795,7 @@ async def foo_loop_static():
     yield
 
     while False:
-        await foo()
+        await foo()  # type: ignore[unreachable]
     yield  # error: 4, "yield", Stmt("yield", line-4)
 
     while "hello":

--- a/tests/test_changelog_and_version.py
+++ b/tests/test_changelog_and_version.py
@@ -95,8 +95,7 @@ class test_messages_documented(unittest.TestCase):
                             # but afaict it should be something like str|Tuple[str,...]
                             # depending on whether there's a group in the pattern or not.
                             # (or bytes, if both inputs are bytes)
-                            assert isinstance(m, str)
-                            documented_errors["eval_files"].add(m)
+                            documented_errors["eval_files"].add(m)  # type: ignore
                         break
 
         for errset in documented_errors.values():

--- a/tests/test_flake8_trio.py
+++ b/tests/test_flake8_trio.py
@@ -30,6 +30,8 @@ from flake8_trio.visitors import ERROR_CLASSES, ERROR_CLASSES_CST
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
+    from flake8_trio.visitors.flake8triovisitor import Flake8TrioVisitor
+
 
 test_files: list[tuple[str, Path]] = sorted(
     (f.stem.upper(), f) for f in (Path(__file__).parent / "eval_files").iterdir()
@@ -64,10 +66,11 @@ def check_version(test: str):
             pytest.skip(f"python version {v_i} smaller than {major}, {minor}")
 
 
-ERROR_CODES = {
-    err_code: err_class
+# mypy does not see that both types have error_codes
+ERROR_CODES: dict[str, Flake8TrioVisitor] = {
+    err_code: err_class  # type: ignore[misc]
     for err_class in (*ERROR_CLASSES, *ERROR_CLASSES_CST)
-    for err_code in err_class.error_codes.keys()
+    for err_code in err_class.error_codes.keys()  # type: ignore[attr-defined]
 }
 
 

--- a/typings/flake8/options/manager.pyi
+++ b/typings/flake8/options/manager.pyi
@@ -5,14 +5,17 @@ Generated for flake8 5, so OptionManager signature is incorrect for flake8 6
 """
 
 import argparse
+import enum
 from collections.abc import Callable, Mapping, Sequence
-from typing import Any
+from typing import Any, TypeAlias
 
 from flake8.plugins.finder import Plugins
 
 """Option handling and Option management logic."""
 LOG = ...
-_ARG = ...
+
+class _ARG(enum.Enum): ...
+
 _optparse_callable_map: dict[str, type[Any] | _ARG] = ...
 
 class _CallbackAction(argparse.Action):


### PR DESCRIPTION
Didn't see an option to warn on unreachable code in pyright, and I tried running Vulture for that but that started requiring me to disable 90%+ of it since it doesn't detect that visitor/leave functions are run, and a lot of other weirdness.
So I settled for running .. another type checker :partying_face: But disabled a couple error codes for now.
It did give some decent warnings on eval files though:
* 103: changing if statements' test from `True` to `...` makes it clearer that the test isn't evaluated
* 104: infinite loops at module level turned off type checking (see #155 )
* 105: noreturn calls have to be split out to get type checking

It does feel silly to run double type checkers, but I'm progressively realizing that linting the h*ck out of the eval files is actually useful - despite how irritating it can be.