### PR TITLE
add libcst as install_requires, print errors to stderr & return 1/0, add pre-commit hook & update config, 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
           - id: black
 
     - repo: https://github.com/PyCQA/autoflake
-      rev: v2.0.1
+      rev: v2.0.2
       hooks:
           - id: autoflake
 
@@ -34,7 +34,7 @@ repos:
           - id: mypy
 
     - repo: https://github.com/RobertCraigie/pyright-python
-      rev: v1.1.298
+      rev: v1.1.299
       hooks:
           - id: pyright
             entry: env PYRIGHT_PYTHON_FORCE_VERSION=latest pyright
@@ -109,7 +109,7 @@ repos:
           - id: yamlfmt
 
     - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-      rev: v2.7.0
+      rev: v2.8.0
       hooks:
           - id: pretty-format-toml
             args: [--autofix]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+---
+    - id: flake8_trio
+      name: flake8_trio
+      entry: flake8_trio
+      language: python
+      types: [python]

--- a/flake8_trio/__init__.py
+++ b/flake8_trio/__init__.py
@@ -74,7 +74,7 @@ def cst_parse_module_native(source: str) -> cst.Module:
     return mod
 
 
-def main():
+def main() -> int:
     parser = ArgumentParser(prog="flake8_trio")
     parser.add_argument(
         nargs="*",
@@ -105,17 +105,20 @@ def main():
                 "Doesn't seem to be a git repo; pass filenames to format.",
                 file=sys.stderr,
             )
-            sys.exit(1)
+            return 1
         all_filenames = [
             os.path.join(root, f) for f in all_filenames if _should_format(f)
         ]
+    any_error = False
     for file in all_filenames:
         plugin = Plugin.from_filename(file)
         for error in sorted(plugin.run()):
             print(f"{file}:{error}")
+            any_error = True
         if plugin.options.autofix:
             with open(file, "w") as file:
                 file.write(plugin.module.code)
+    return 1 if any_error else 0
 
 
 class Plugin:

--- a/flake8_trio/__main__.py
+++ b/flake8_trio/__main__.py
@@ -1,4 +1,6 @@
 """Entry file when executed with `python -m`."""
+import sys
+
 from . import main
 
-main()
+sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     license="MIT",
     description="A highly opinionated flake8 plugin for Trio-related problems.",
     zip_safe=False,
-    install_requires=["flake8"],
+    install_requires=["flake8", "libcst"],
     python_requires=">=3.9",
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Didn't come up with any good ways of writing an automated test for pre-commit, but tested it locally and against my fork - and therefore finding the catastrophically bad errors in init & setup :sweat_smile: 
I was a bit surprised missing libcst wasn't picked up by tox, but that's because the testenv depends on hypothesmith - which requires libcst.

We surely want to start tagging releases though, I looked at shed's CI workflow if there were anything there that automatically created tags but didn't find anything so I'm a bit curious if/how you automate that or if you manually do it on releasing.