### PR TITLE
Run black with --preview

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
       rev: 23.1.0
       hooks:
           - id: black
+            args: [--preview]
 
     - repo: https://github.com/PyCQA/autoflake
       rev: v2.0.1

--- a/flake8_trio/visitors/visitor103_104.py
+++ b/flake8_trio/visitors/visitor103_104.py
@@ -31,9 +31,9 @@ class Visitor103_104(Flake8TrioVisitor):
         "TRIO104": "Cancelled (and therefore BaseException) must be re-raised.",
     }
     for poss_library in _suggestion_dict:
-        error_codes[
-            f"TRIO103_{'_'.join(poss_library)}"
-        ] = _trio103_common_msg + _suggestion.format(_suggestion_dict[poss_library])
+        error_codes[f"TRIO103_{'_'.join(poss_library)}"] = (
+            _trio103_common_msg + _suggestion.format(_suggestion_dict[poss_library])
+        )
 
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)

--- a/flake8_trio/visitors/visitor2xx.py
+++ b/flake8_trio/visitors/visitor2xx.py
@@ -226,8 +226,8 @@ class Visitor22X(Visitor200):
 @error_class
 class Visitor23X(Visitor200):
     error_codes = {
-        "TRIO230": ("Sync call {0} in async function, use `{1}.open_file(...)`."),
-        "TRIO231": ("Sync call {0} in async function, use `{1}.wrap_file({0})`."),
+        "TRIO230": "Sync call {0} in async function, use `{1}.open_file(...)`.",
+        "TRIO231": "Sync call {0} in async function, use `{1}.wrap_file({0})`.",
     }
 
     def visit_Call(self, node: ast.Call):
@@ -282,7 +282,7 @@ class Visitor232(Visitor200):
 @error_class
 class Visitor24X(Visitor200):
     error_codes = {
-        "TRIO240": ("Avoid using os.path, prefer using {1}.Path objects."),
+        "TRIO240": "Avoid using os.path, prefer using {1}.Path objects.",
     }
 
     def __init__(self, *args: Any, **kwargs: Any):

--- a/flake8_trio/visitors/visitors.py
+++ b/flake8_trio/visitors/visitors.py
@@ -268,7 +268,7 @@ DEPRECATED_ERRORS = ("MultiError", "NonBaseMultiError")
 @error_class
 class Visitor117(Flake8TrioVisitor):
     error_codes = {
-        "TRIO117": ("Reference to {}, prefer [exceptiongroup.]BaseExceptionGroup."),
+        "TRIO117": "Reference to {}, prefer [exceptiongroup.]BaseExceptionGroup.",
     }
 
     # This should never actually happen given TRIO106
@@ -285,7 +285,7 @@ class Visitor117(Flake8TrioVisitor):
 @disabled_by_default
 class Visitor900(Flake8TrioVisitor):
     error_codes = {
-        "TRIO900": ("Async generator without `@asynccontextmanager` not allowed.")
+        "TRIO900": "Async generator without `@asynccontextmanager` not allowed."
     }
 
     def __init__(self, *args: Any, **kwargs: Any):

--- a/tests/test_flake8_trio.py
+++ b/tests/test_flake8_trio.py
@@ -293,9 +293,7 @@ def _parse_eval_file(test: str, content: str) -> tuple[list[Error], list[str]]:
             try:
                 expected.append(Error(err_code, lineno, int(col), message, *args))
             except AttributeError as e:
-                msg = (
-                    f"Line {lineno}: Failed to format\n {message!r}\n" f'"with\n{args}'
-                )
+                msg = f'Line {lineno}: Failed to format\n {message!r}\n"with\n{args}'
                 raise ParseError(msg) from e
 
     for error in expected:


### PR DESCRIPTION
They've improved multi-line string handling, which I otherwise find quite irritating with the loads of long strings everywhere (e.g. currently writing help texts for command line args).