### PR TITLE
add standalone command line args

### DIFF
--- a/flake8_trio/base.py
+++ b/flake8_trio/base.py
@@ -2,7 +2,25 @@
 
 from __future__ import annotations
 
-from typing import Any, NamedTuple
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, NamedTuple
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
+
+
+@dataclass
+class Options:
+    # error codes to give errors for
+    enabled_codes: set[str]
+    # error codes to autofix
+    autofix_codes: set[str]
+    # whether to print an error message even when autofixed
+    error_on_autofix: bool
+    no_checkpoint_warning_decorators: Collection[str]
+    startable_in_context_manager: Collection[str]
+    trio200_blocking_calls: dict[str, str]
+    anyio: bool
 
 
 class Statement(NamedTuple):

--- a/flake8_trio/visitors/visitor100.py
+++ b/flake8_trio/visitors/visitor100.py
@@ -58,7 +58,7 @@ class Visitor100_libcst(Flake8TrioVisitor_cst):
             for res in self.node_dict[original_node]:
                 self.error(res.node, res.base, res.function)
 
-            if self.options.autofix and len(updated_node.items) == 1:
+            if self.should_autofix() and len(updated_node.items) == 1:
                 return flatten_preserving_comments(updated_node)
 
         return updated_node

--- a/tests/autofix_files/trio910.py
+++ b/tests/autofix_files/trio910.py
@@ -19,7 +19,7 @@ def bar() -> Any:
     ...
 
 
-# ARG --enable-visitor-codes-regex=(TRIO910)|(TRIO911)
+# ARG --enable=TRIO910,TRIO911
 # ARG --no-checkpoint-warning-decorator=custom_disabled_decorator
 
 

--- a/tests/autofix_files/trio911.py
+++ b/tests/autofix_files/trio911.py
@@ -6,7 +6,7 @@ import trio
 
 _: Any = ""
 
-# ARG --enable-visitor-codes-regex=(TRIO910)|(TRIO911)
+# ARG --enable=TRIO910,TRIO911
 
 
 async def foo() -> Any:

--- a/tests/autofix_files/trio91x_autofix.py
+++ b/tests/autofix_files/trio91x_autofix.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 So we make sure that import is added after it.
 """
 # isort: skip_file
-# ARG --enable-visitor-codes-regex=(TRIO910)|(TRIO911)
+# ARG --enable=TRIO910,TRIO911
 
 from typing import Any
 import trio

--- a/tests/autofix_files/trio91x_autofix.py.diff
+++ b/tests/autofix_files/trio91x_autofix.py.diff
@@ -1,7 +1,7 @@
 ---
 +++
 @@ -9,6 +9,7 @@
- # ARG --enable-visitor-codes-regex=(TRIO910)|(TRIO911)
+ # ARG --enable=TRIO910,TRIO911
 
  from typing import Any
 +import trio

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,8 +16,8 @@ def pytest_addoption(parser: pytest.Parser):
         help="generate autofix file content",
     )
     parser.addoption(
-        "--enable-visitor-codes-regex",
-        default=".*",
+        "--enable-codes",
+        default="TRIO",
         help="select error codes whose visitors to run.",
     )
 
@@ -44,5 +44,5 @@ def generate_autofix(request: pytest.FixtureRequest):
 
 
 @pytest.fixture()
-def enable_visitor_codes_regex(request: pytest.FixtureRequest):
-    return request.config.getoption("--enable-visitor-codes-regex")
+def enable_codes(request: pytest.FixtureRequest):
+    return request.config.getoption("--enable-codes")

--- a/tests/eval_files/anyio_trio.py
+++ b/tests/eval_files/anyio_trio.py
@@ -1,5 +1,5 @@
 # type: ignore
-# ARG --enable-visitor-codes-regex=(TRIO220)
+# ARG --enable=TRIO220
 # NOTRIO
 
 # anyio eval will automatically prepend this test with `--anyio`

--- a/tests/eval_files/no_library.py
+++ b/tests/eval_files/no_library.py
@@ -1,5 +1,5 @@
 # type: ignore
-# ARG --enable-visitor-codes-regex=(TRIO220)
+# ARG --enable=TRIO220
 # NOANYIO
 async def foo():
     subprocess.Popen()  # TRIO220: 4, 'subprocess.Popen', "trio"

--- a/tests/eval_files/trio103.py
+++ b/tests/eval_files/trio103.py
@@ -1,4 +1,4 @@
-# ARG --enable-visitor-codes-regex=(TRIO103)|(TRIO104)
+# ARG --enable=TRIO103,TRIO104
 
 from typing import Any
 
@@ -210,6 +210,16 @@ try:
     ...
 except BaseException as e:
     for i in [1, 2, 3]:
+        raise
+try:
+    ...
+except BaseException as e:
+    for i in (1, 2, 3):
+        raise
+try:
+    ...
+except BaseException as e:
+    for i in {1, 2, 3}:
         raise
 
 try:

--- a/tests/eval_files/trio103_no_104.py
+++ b/tests/eval_files/trio103_no_104.py
@@ -1,4 +1,4 @@
-# ARG --enable-visitor-codes-regex=TRIO103
+# ARG --enable=TRIO103
 # check that partly disabling a visitor works
 from typing import Any
 

--- a/tests/eval_files/trio103_trio.py
+++ b/tests/eval_files/trio103_trio.py
@@ -1,4 +1,4 @@
-# ARG --enable-visitor-codes-regex=(TRIO103)|(TRIO104)
+# ARG --enable=TRIO103,TRIO104
 # NOANYIO
 
 from typing import Any

--- a/tests/eval_files/trio104.py
+++ b/tests/eval_files/trio104.py
@@ -1,4 +1,4 @@
-# ARG --enable-visitor-codes-regex=(TRIO103)|(TRIO104)
+# ARG --enable=TRIO103,TRIO104
 try:
     ...
 # raise different exception

--- a/tests/eval_files/trio22x.py
+++ b/tests/eval_files/trio22x.py
@@ -1,5 +1,5 @@
 # type: ignore
-# ARG --enable-visitor-codes-regex=(TRIO220|TRIO221|TRIO222)
+# ARG --enable=TRIO220,TRIO221,TRIO222
 
 
 async def foo():

--- a/tests/eval_files/trio23x.py
+++ b/tests/eval_files/trio23x.py
@@ -1,5 +1,5 @@
 # type: ignore
-# ARG --enable-visitor-codes-regex=(TRIO230)|(TRIO231)
+# ARG --enable=TRIO230,TRIO231
 import io
 import os
 

--- a/tests/eval_files/trio910.py
+++ b/tests/eval_files/trio910.py
@@ -19,7 +19,7 @@ def bar() -> Any:
     ...
 
 
-# ARG --enable-visitor-codes-regex=(TRIO910)|(TRIO911)
+# ARG --enable=TRIO910,TRIO911
 # ARG --no-checkpoint-warning-decorator=custom_disabled_decorator
 
 

--- a/tests/eval_files/trio911.py
+++ b/tests/eval_files/trio911.py
@@ -6,7 +6,7 @@ import trio
 
 _: Any = ""
 
-# ARG --enable-visitor-codes-regex=(TRIO910)|(TRIO911)
+# ARG --enable=TRIO910,TRIO911
 
 
 async def foo() -> Any:

--- a/tests/eval_files/trio91x_autofix.py
+++ b/tests/eval_files/trio91x_autofix.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 So we make sure that import is added after it.
 """
 # isort: skip_file
-# ARG --enable-visitor-codes-regex=(TRIO910)|(TRIO911)
+# ARG --enable=TRIO910,TRIO911
 
 from typing import Any
 

--- a/tests/eval_files/trio91x_noautofix.py
+++ b/tests/eval_files/trio91x_noautofix.py
@@ -1,4 +1,4 @@
-# ARG --enable-visitor-codes-regex=(TRIO910)|(TRIO911)
+# ARG --enable=TRIO910,TRIO911
 from typing import Any
 
 

--- a/tests/eval_files/trio_anyio.py
+++ b/tests/eval_files/trio_anyio.py
@@ -1,5 +1,5 @@
 # type: ignore
-# ARG --enable-visitor-codes-regex=(TRIO220)
+# ARG --enable=TRIO220
 # NOANYIO
 import trio  # isort: skip
 import anyio  # isort: skip

--- a/tests/test_changelog_and_version.py
+++ b/tests/test_changelog_and_version.py
@@ -88,7 +88,7 @@ class test_messages_documented(unittest.TestCase):
 
             with open(file_path) as file:
                 for line in file:
-                    if line.startswith("# ARG --enable-visitor-codes-regex"):
+                    if line.startswith("# ARG --enable"):
                         for m in re.findall(r"trio\d\d\d", line, re.IGNORECASE):
                             # pyright types m as `Any` (as it is in typeshed)
                             # mypy types it as Optional[Match[str]]


### PR DESCRIPTION
And just for funsies let's open a fourth PR :grin: 
It's branched on top of #162, so the diff will be *slightly* smaller once that's merged.

Ready for review, though I can probably polish it a bit if giving it another look tomorrow.
Had a decently long thonk on whether to just have an `--enable` and no `--disable`, or whether to get the full flake8 experience with `--extend-[...]` flags. Settled on this compromise.

91x does not respect `--autofix` parameter value properly atm, hence the commented out code with that, would like #159 in order to work on that.

Will probably have some merge conflicts and need rebasing once other PR's get merged