### PR TITLE
respect noqa

### DIFF
--- a/flake8_trio/base.py
+++ b/flake8_trio/base.py
@@ -63,7 +63,8 @@ class Error:
         yield None
 
     def cmp(self):
-        return self.line, self.col, self.code, self.args
+        # column may be ignored/modified when autofixing, so sort on that last
+        return self.line, self.code, self.args, self.col
 
     # for sorting in tests
     def __lt__(self, other: Any) -> bool:

--- a/flake8_trio/runner.py
+++ b/flake8_trio/runner.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 class SharedState:
     options: Options
     problems: list[Error] = field(default_factory=list)
+    noqas: dict[int, set[str]] = field(default_factory=dict)
     library: tuple[str, ...] = ()
     typed_calls: dict[str, str] = field(default_factory=dict)
     variables: dict[str, str] = field(default_factory=dict)
@@ -129,4 +130,10 @@ class Flake8TrioRunner_cst(__CommonRunner):
             return
         for v in (*self.utility_visitors, *self.visitors):
             self.module = cst.MetadataWrapper(self.module).visit(v)
-        yield from self.state.problems
+
+        for problem in self.state.problems:
+            noqa = self.state.noqas.get(problem.line)
+            # if there's a noqa comment, and it's bare or this code is listed in it
+            if noqa is not None and (noqa == set() or problem.code in noqa):
+                continue
+            yield problem

--- a/flake8_trio/visitors/flake8triovisitor.py
+++ b/flake8_trio/visitors/flake8triovisitor.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 class Flake8TrioVisitor(ast.NodeVisitor, ABC):
     # abstract attribute by not providing a value
-    error_codes: dict[str, str]  # pyright: reportUninitializedInstanceVariable=false
+    error_codes: dict[str, str]  # pyright: ignore[reportUninitializedInstanceVariable]
 
     def __init__(self, shared_state: SharedState):
         super().__init__()
@@ -158,7 +158,7 @@ class Flake8TrioVisitor(ast.NodeVisitor, ABC):
 
 class Flake8TrioVisitor_cst(cst.CSTTransformer, ABC):
     # abstract attribute by not providing a value
-    error_codes: dict[str, str]  # pyright: reportUninitializedInstanceVariable=false
+    error_codes: dict[str, str]  # pyright: ignore[reportUninitializedInstanceVariable]
     METADATA_DEPENDENCIES = (PositionProvider,)
 
     def __init__(self, shared_state: SharedState):
@@ -167,6 +167,7 @@ class Flake8TrioVisitor_cst(cst.CSTTransformer, ABC):
         self.__state = shared_state
 
         self.options = self.__state.options
+        self.noqas = self.__state.noqas
 
     def get_state(self, *attrs: str, copy: bool = False) -> dict[str, Any]:
         # require attrs, since we inherit a *ton* of stuff which we don't want to copy

--- a/tests/eval_files/noqa.py
+++ b/tests/eval_files/noqa.py
@@ -1,0 +1,36 @@
+# NOAUTOFIX - TODO TODO TODO
+# NOANYIO
+# ARG --enable=TRIO100,TRIO911
+import trio
+
+
+# fmt: off
+async def foo_no_noqa():
+    with trio.fail_after(5): yield  # TRIO100: 9, 'trio', 'fail_after'  # TRIO911: 29, "yield", Statement("function definition", lineno-1)
+    await trio.lowlevel.checkpoint()
+
+
+async def foo_noqa_bare():
+    with trio.fail_after(5): yield  # noqa
+    await trio.lowlevel.checkpoint()
+
+
+async def foo_noqa_101():
+    with trio.fail_after(5): yield  # noqa: TRIO100  # TRIO911: 29, "yield", Statement("function definition", lineno-1)
+    await trio.lowlevel.checkpoint()
+
+
+async def foo_noqa_911():
+    with trio.fail_after(5): yield  # noqa: TRIO911  # TRIO100: 9, 'trio', 'fail_after'
+    await trio.lowlevel.checkpoint()
+
+
+async def foo_noqa_101_911():
+    with trio.fail_after(5): yield  # noqa: TRIO100, TRIO911
+    await trio.lowlevel.checkpoint()
+
+
+async def foo_noqa_101_911_500():
+    with trio.fail_after(5): yield  # noqa: TRIO100, TRIO911 , TRIO500,,,
+    await trio.lowlevel.checkpoint()
+# fmt: on

--- a/tox.ini
+++ b/tox.ini
@@ -53,6 +53,9 @@ extend-enable = TC10
 exclude = .*, tests/eval_files/*, tests/autofix_files/*
 per-file-ignores =
     flake8_trio/visitors/__init__.py: F401, E402
+# visitor_utility contains comments specifying how it parses noqa comments, which get
+# parsed as noqa comments
+    flake8_trio/visitors/visitor_utility.py: NQA101, NQA102
 # (E301, E302) black formats stub files without excessive blank lines
 # (D) we don't care about docstrings in stub files
     *.pyi: D, E301, E302


### PR DESCRIPTION
fixes #181 
Implemented:
* respects `noqa`
* new pyright error about how to in-line silence stuff.
  * it would be nice to catch errors-due-to-updated-linters with a bot, instead of me randomly encountering them when writing new PRs and being surprised.
* various small test improvements
  * changes parametrized params to `test_eval` so summaries are more informative than e.g. `test_eval[False, True, TRIO100, path7]`
  * sort errors on columns late, since columns have a habit of getting messed up and thrown around (and might be ignored anyway)
  * ignore columns when checking with autofix
    * the scenario here is two errors on the same line, the first which modifies the line, causing the second to have a different column

remaining TODO:
* don't autofix `noqa`'d errors
  * ... ah shit, I have to kind of completely change when errors get suppressed to fix this - since visitors have to know if an error is `noqa`d when they raise/autofix it.
* support `noqa-trio` (or similar / depends on discussion in #181)
  * handle NQA102 for `noqa-trio`
    * separate error, or command-line flag, if code not enabled
  * check that ignored code is valid/exists
    * maybe give separate error if it's not enabled, see above
* autofixing two errors in the same line seems broken
  * TRIO100 autofix looks like it's eating comments
  * TRIO911 autofix does not get executed, although that's possibly due to it being a `SimpleStatementSuite`
  * might fix these in a separate PR which i rebase this onto, or just do `NOAUTOFIX`
* noqas with invalid code is parsed as bare noqa (but that's same as flake8, so /shrug )
* report old regex101.com link upstream in PyCQA/flake8
* don't suppress errors when running as a plugin
* `--disable-noqa`