### PR TITLE
don't autofix noqa'd errors, add --disable-noqa, add non-passing test for noqa reliability

### DIFF
--- a/flake8_trio/base.py
+++ b/flake8_trio/base.py
@@ -21,6 +21,7 @@ class Options:
     startable_in_context_manager: Collection[str]
     trio200_blocking_calls: dict[str, str]
     anyio: bool
+    disable_noqa: bool
 
 
 class Statement(NamedTuple):

--- a/flake8_trio/visitors/visitor100.py
+++ b/flake8_trio/visitors/visitor100.py
@@ -55,10 +55,13 @@ class Visitor100_libcst(Flake8TrioVisitor_cst):
         self, original_node: cst.With, updated_node: cst.With
     ) -> cst.BaseStatement | cst.FlattenSentinel[cst.BaseStatement]:
         if not self.has_checkpoint_stack.pop():
+            autofix = len(updated_node.items) == 1
             for res in self.node_dict[original_node]:
-                self.error(res.node, res.base, res.function)
+                autofix &= self.error(
+                    res.node, res.base, res.function
+                ) and self.should_autofix(res.node)
 
-            if self.should_autofix() and len(updated_node.items) == 1:
+            if autofix:
                 return flatten_preserving_comments(updated_node)
 
         return updated_node

--- a/flake8_trio/visitors/visitor101.py
+++ b/flake8_trio/visitors/visitor101.py
@@ -60,6 +60,7 @@ class Visitor101(Flake8TrioVisitor_cst):
             node, "contextmanager", "asynccontextmanager", "fixture"
         )
 
+    # trigger on leaving yield so any comments are parsed for noqas
     def visit_Yield(self, node: cst.Yield):
         if self._yield_is_error:
             self.error(node)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ warn_unused_ignores = false
 [tool.pyright]
 exclude = ["**/node_modules", "**/__pycache__", "**/.*"]
 reportCallInDefaultInitializer = true
-reportImplicitStringConcatenation = true
+reportImplicitStringConcatenation = false  # black generates implicit string concats
 reportMissingSuperCall = true
 reportPropertyTypeMismatch = true
 reportShadowedImports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ warn_unreachable = true
 warn_unused_ignores = false
 
 [tool.pyright]
-exclude = ["**/node_modules", "**/__pycache__", "**/.*"]
+exclude = ["**/node_modules", "**/__pycache__", "**/.*", "tests/eval_files/*", "tests/autofix_files/*"]  # TODO: fix errors in eval/autofix files
 reportCallInDefaultInitializer = true
 reportImplicitStringConcatenation = false  # black generates implicit string concats
 reportMissingSuperCall = true

--- a/tests/autofix_files/noqa.py
+++ b/tests/autofix_files/noqa.py
@@ -8,8 +8,9 @@ import trio
 
 # fmt: off
 async def foo_no_noqa():
-    with trio.fail_after(5):  # TRIO100: 9, 'trio', 'fail_after'
-        yield  # TRIO911: 8, "yield", Statement("function definition", lineno-2)
+    await trio.lowlevel.checkpoint()
+    # TRIO100: 9, 'trio', 'fail_after'
+    yield  # TRIO911: 8, "yield", Statement("function definition", lineno-2)
     await trio.lowlevel.checkpoint()
 
 
@@ -21,13 +22,14 @@ async def foo_noqa_bare():
 
 async def foo_noqa_100():
     with trio.fail_after(5):  # noqa: TRIO100
+        await trio.lowlevel.checkpoint()
         yield  # TRIO911: 8, "yield", Statement("function definition", lineno-2)
     await trio.lowlevel.checkpoint()
 
 
 async def foo_noqa_911():
-    with trio.fail_after(5):  # TRIO100: 9, 'trio', 'fail_after'
-        yield  # noqa: TRIO911
+    # TRIO100: 9, 'trio', 'fail_after'
+    yield  # noqa: TRIO911
     await trio.lowlevel.checkpoint()
 
 
@@ -46,8 +48,8 @@ async def foo_noqa_100_911_500():
 # check that noqas work after line numbers have been modified in a different visitor
 
 # this will remove one line
-with trio.fail_after(5):  # TRIO100: 5, 'trio', 'fail_after'
-    ...
+# TRIO100: 5, 'trio', 'fail_after'
+...
 
 
 async def foo_changed_lineno():
@@ -57,7 +59,9 @@ async def foo_changed_lineno():
 
 # this will add two lines
 async def foo_changing_lineno():  # TRIO911: 0, "exit", Statement("yield", lineno+1)
+    await trio.lowlevel.checkpoint()
     yield  # TRIO911: 4, "yield", Statement("function definition", lineno-1)
+    await trio.lowlevel.checkpoint()
 
 
 with trio.fail_after(5):  # noqa: TRIO100

--- a/tests/autofix_files/noqa.py.diff
+++ b/tests/autofix_files/noqa.py.diff
@@ -1,0 +1,52 @@
+---
++++
+@@ x,8 x,9 @@
+
+ # fmt: off
+ async def foo_no_noqa():
+-    with trio.fail_after(5):  # TRIO100: 9, 'trio', 'fail_after'
+-        yield  # TRIO911: 8, "yield", Statement("function definition", lineno-2)
++    await trio.lowlevel.checkpoint()
++    # TRIO100: 9, 'trio', 'fail_after'
++    yield  # TRIO911: 8, "yield", Statement("function definition", lineno-2)
+     await trio.lowlevel.checkpoint()
+
+
+@@ x,13 x,14 @@
+
+ async def foo_noqa_100():
+     with trio.fail_after(5):  # noqa: TRIO100
++        await trio.lowlevel.checkpoint()
+         yield  # TRIO911: 8, "yield", Statement("function definition", lineno-2)
+     await trio.lowlevel.checkpoint()
+
+
+ async def foo_noqa_911():
+-    with trio.fail_after(5):  # TRIO100: 9, 'trio', 'fail_after'
+-        yield  # noqa: TRIO911
++    # TRIO100: 9, 'trio', 'fail_after'
++    yield  # noqa: TRIO911
+     await trio.lowlevel.checkpoint()
+
+
+@@ x,8 x,8 @@
+ # check that noqas work after line numbers have been modified in a different visitor
+
+ # this will remove one line
+-with trio.fail_after(5):  # TRIO100: 5, 'trio', 'fail_after'
+-    ...
++# TRIO100: 5, 'trio', 'fail_after'
++...
+
+
+ async def foo_changed_lineno():
+@@ x,7 x,9 @@
+
+ # this will add two lines
+ async def foo_changing_lineno():  # TRIO911: 0, "exit", Statement("yield", lineno+1)
++    await trio.lowlevel.checkpoint()
+     yield  # TRIO911: 4, "yield", Statement("function definition", lineno-1)
++    await trio.lowlevel.checkpoint()
+
+
+ with trio.fail_after(5):  # noqa: TRIO100

--- a/tests/autofix_files/noqa_testing.py
+++ b/tests/autofix_files/noqa_testing.py
@@ -1,0 +1,10 @@
+# AUTOFIX
+# NOANYIO # TODO
+# ARG --enable=TRIO911
+import trio
+
+
+async def foo_0():
+    await trio.lowlevel.checkpoint()
+    yield  # TRIO911: 4, "yield", Statement("function definition", lineno-1)
+    await trio.lowlevel.checkpoint()

--- a/tests/autofix_files/noqa_testing.py.diff
+++ b/tests/autofix_files/noqa_testing.py.diff
@@ -1,0 +1,9 @@
+---
++++
+@@ x,5 x,6 @@
+
+
+ async def foo_0():
++    await trio.lowlevel.checkpoint()
+     yield  # TRIO911: 4, "yield", Statement("function definition", lineno-1)
+     await trio.lowlevel.checkpoint()

--- a/tests/eval_files/noqa_no_autofix.py
+++ b/tests/eval_files/noqa_no_autofix.py
@@ -1,0 +1,30 @@
+# ARG --enable=TRIO102
+
+import trio
+from typing import Any
+
+
+# errors from AST visitors
+async def foo() -> Any:
+    ...
+
+
+async def foo_no_noqa_102():
+    try:
+        pass
+    finally:
+        await foo()  # TRIO102: 8, Statement("try/finally", lineno-3)
+
+
+async def foo_noqa_102():
+    try:
+        pass
+    finally:
+        await foo()  # noqa: TRIO102
+
+
+async def foo_bare_noqa_102():
+    try:
+        pass
+    finally:
+        await foo()  # noqa

--- a/tests/eval_files/noqa_testing.py
+++ b/tests/eval_files/noqa_testing.py
@@ -1,0 +1,9 @@
+# AUTOFIX
+# NOANYIO # TODO
+# ARG --enable=TRIO911
+import trio
+
+
+async def foo_0():
+    yield  # TRIO911: 4, "yield", Statement("function definition", lineno-1)
+    await trio.lowlevel.checkpoint()

--- a/tests/eval_files/trio106.py
+++ b/tests/eval_files/trio106.py
@@ -1,11 +1,12 @@
 # type: ignore
+# isort: skip
 import importlib
 
 import trio
 import trio as foo  # error: 0, "trio"
 from foo import blah
-from trio import *  # type: ignore # noqa # error: 0, "trio"
-from trio import blah, open_file as foo  # noqa # error: 0, "trio"
+from trio import *  # error: 0, "trio"
+from trio import blah, open_file as foo  # error: 0, "trio"
 
 # Note that our tests exercise the Visitor classes, without going through the noqa filter later in flake8 - so these suppressions are picked up by our project-wide linter stack but not the tests.
 

--- a/tests/eval_files/trio22x.py
+++ b/tests/eval_files/trio22x.py
@@ -3,6 +3,9 @@
 
 
 async def foo():
+    await async_fun(
+        subprocess.getoutput()  # TRIO221: 8, 'subprocess.getoutput', "trio"
+    )
     subprocess.Popen()  # TRIO220: 4, 'subprocess.Popen', "trio"
     os.system()  # TRIO221: 4, 'os.system', "trio"
 


### PR DESCRIPTION
big refactor for noqa functionality fixing most of the remaining ones in #185, but as I added the test for all errors being properly noqa'd and was greeted with a wall of errors I realized it might be good to commit and push before tackling them. If it's a minor fix I'll just push/amend it to this PR, otherwise open a separate one.

* ~~Moves `# noqa` logic into `Flake8TrioVisitor_cst`, other than for ast visitors where some logic still is in `__init__.py`~~
  * ~~utility visitor `NoqaHandler` removed~~
* add `--disable-noqa`, and use that instead of whether we're standalone to decide whether to parse noqa or not.
* ~~the list of `noqas` is no longer parsed once by a utility visitor, but instead parsed by each visitor. This is a performance hit (though probably not very large, if any) but is sorta necessary as autofixing messes up line numbers.~~ autofixing does *not* mess up line numbers in fact.
* `should_autofix` now takes a `CSTNode` parameter so it can determine the line number of it, and check if it's noqa'd
* ~~`visitor91x` now doesn't autofix simple `noqa` scenarios, but doesn't handle loops and the like~~ visitor91x handles all cases
* tests and shit