### PR TITLE
add version requirements on flake8&libcst

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     license="MIT",
     description="A highly opinionated flake8 plugin for Trio-related problems.",
     zip_safe=False,
-    install_requires=["flake8", "libcst"],
+    install_requires=["flake8>=5", "libcst>=0.4"],
     python_requires=">=3.9",
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
while playing around I realized the `install_requires` weren't specified at all, so I quickly figured out minimum required versions for tests to pass and added them.