### PR TITLE
use ruff noqa handling

### DIFF
--- a/flake8_trio/visitors/helpers.py
+++ b/flake8_trio/visitors/helpers.py
@@ -146,7 +146,7 @@ def iter_guaranteed_once(iterable: ast.expr) -> bool:
     ):
         try:
             values = [ast.literal_eval(a) for a in iterable.args]
-        except Exception:  # noqa: PIE786
+        except Exception:
             # parameters aren't literal
             return False
 

--- a/flake8_trio/visitors/visitor103_104.py
+++ b/flake8_trio/visitors/visitor103_104.py
@@ -177,7 +177,7 @@ class Visitor103_104(Flake8TrioVisitor):
         if isinstance(node, ast.While):
             try:
                 infinite_loop = body_guaranteed_once = bool(ast.literal_eval(node.test))
-            except Exception:  # noqa: PIE786
+            except Exception:
                 body_guaranteed_once = False
             self.visit_nodes(node.test)
         else:

--- a/flake8_trio/visitors/visitor91x.py
+++ b/flake8_trio/visitors/visitor91x.py
@@ -307,7 +307,7 @@ class Visitor91X(Flake8TrioVisitor_cst, CommonVisitors):
             updated_node = updated_node.with_changes(body=indentedblock)
 
         self.restore_state(original_node)
-        return updated_node  # noqa: R504
+        return updated_node
 
     # error if function exit/return/yields with uncheckpointed statements
     # returns a bool indicating if any real (i.e. not artificial) errors were raised
@@ -686,7 +686,7 @@ class Visitor91X(Flake8TrioVisitor_cst, CommonVisitors):
 
         self.restore_state(original_node)
         # https://github.com/afonasev/flake8-return/issues/133
-        return updated_node  # noqa: R504
+        return updated_node
 
     leave_For = leave_While
 

--- a/flake8_trio/visitors/visitor_utility.py
+++ b/flake8_trio/visitors/visitor_utility.py
@@ -147,13 +147,14 @@ class VisitorLibraryHandler_cst(Flake8TrioVisitor_cst):
 # https://github.com/PyCQA/flake8/blob/d016204366a22d382b5b56dc14b6cbff28ce929e/src/flake8/defaults.py#L27
 NOQA_INLINE_REGEXP = re.compile(
     # We're looking for items that look like this:
-    # ``# noqa``
-    # ``# noqa: E123``
-    # ``# noqa: E123,W451,F921``
-    # ``# noqa:E123,W451,F921``
-    # ``# NoQA: E123,W451,F921``
-    # ``# NOQA: E123,W451,F921``
-    # ``# NOQA:E123,W451,F921``
+    # ``# nxqa``
+    # ``# nxqa: E123``
+    # ``# nxqa: E123,W451,F921``
+    # ``# nxqa:E123,W451,F921``
+    # ``# NxQA: E123,W451,F921``
+    # ``# NXQA: E123,W451,F921``
+    # ``# NXQA:E123,W451,F921``
+    # (o/O replaced with x/X to avoid the wrath of flake8-noqa/RUF100)
     # We do not want to capture the ``: `` that follows ``noqa``
     # We do not care about the casing of ``noqa``
     # We want a comma-separated list of errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,10 +87,7 @@ ignore = [
   'TD003',  # missing issue link in TODO
   'TRY003',  # Avoid specifying long messages outside the exception class
   'TRY200',  # Use `raise from` to specify exception cause
-  'TRY201',  # Use `raise` without specifying exception name
-  # enable if flake8/plugins are removed
-  'PGH004',  # Use specific rule codes when using `noqa`
-  'RUF100'  # Unused `noqa` - enable only if flake8 is no longer used
+  'TRY201'  # Use `raise` without specifying exception name
 ]
 line-length = 90
 select = ["ALL"]

--- a/tests/test_config_and_args.py
+++ b/tests/test_config_and_args.py
@@ -69,7 +69,7 @@ def test_systemexit_0(
     tmp_path.joinpath("example.py").write_text("")
 
     with pytest.raises(SystemExit) as exc_info:
-        from flake8_trio import __main__  # noqa
+        from flake8_trio import __main__  # noqa: F401
 
     assert exc_info.value.code == 0
     out, err = capsys.readouterr()
@@ -84,7 +84,7 @@ def test_systemexit_1(
     monkeypatch_argv(monkeypatch, tmp_path)
 
     with pytest.raises(SystemExit) as exc_info:
-        from flake8_trio import __main__  # noqa
+        from flake8_trio import __main__  # noqa: F401
 
     assert exc_info.value.code == 1
     out, err = capsys.readouterr()

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,8 @@ exclude_lines =
 
 [flake8]
 max-line-length = 90
-extend-ignore = S101, D101, D102, D103, D105, D106, D107
+# not supported by ruff + want to `noqa` them, so instead ignoring them: PIE786, R504
+extend-ignore = S101, D101, D102, D103, D105, D106, D107, PIE786, R504
 extend-enable = TC10
 exclude = .*, tests/eval_files/*, tests/autofix_files/*
 per-file-ignores =


### PR DESCRIPTION
enables the `noqa` checks in ruff, removing the noqa comments on rules not enforced by it, and disabling those rules in flake8.


unrelated:
randomly noticed that pretty-format-toml doesn't enforce consistent usage of `'` vs `"` for strings, so that's kind of a mess :unamused: 