### PR TITLE
Warn on `ExceptionGroup` subclasses without a `.derive()` method

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ Unreleased
 - :ref:`ASYNC910 <async910>` and :ref:`ASYNC911 <async911>` now accept ``__aenter__`` / ``__aexit__`` methods when the partner method provides the checkpoint, or when only one of the two is defined on a class that inherits from another class (charitably assuming the partner is inherited and contains a checkpoint). `(issue #441) <https://github.com/python-trio/flake8-async/issues/441>`_
 - :ref:`ASYNC300 <async300>` no longer triggers when the result of ``asyncio.create_task()`` is returned from a function. `(issue #398) <https://github.com/python-trio/flake8-async/issues/398>`_
 - Add :ref:`ASYNC126 <async126>` exceptiongroup-subclass-missing-derive. `(issue #334) <https://github.com/python-trio/flake8-async/issues/334>`_
+- :ref:`ASYNC102 <async102>` no longer warns on ``await trio.aclose_forcefully(...)`` / ``await anyio.aclose_forcefully(...)``, which are designed for cleanup and cancel immediately by design. `(issue #446) <https://github.com/python-trio/flake8-async/issues/446>`_
 
 25.7.1
 ======

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Unreleased
 - Autofix for :ref:`ASYNC910 <async910>` / :ref:`ASYNC911 <async911>` no longer inserts checkpoints inside ``except`` clauses (which would trigger :ref:`ASYNC120 <async120>`); instead the checkpoint is added at the top of the function or of the enclosing loop. `(issue #403) <https://github.com/python-trio/flake8-async/issues/403>`_
 - :ref:`ASYNC910 <async910>` and :ref:`ASYNC911 <async911>` now accept ``__aenter__`` / ``__aexit__`` methods when the partner method provides the checkpoint, or when only one of the two is defined on a class that inherits from another class (charitably assuming the partner is inherited and contains a checkpoint). `(issue #441) <https://github.com/python-trio/flake8-async/issues/441>`_
 - :ref:`ASYNC300 <async300>` no longer triggers when the result of ``asyncio.create_task()`` is returned from a function. `(issue #398) <https://github.com/python-trio/flake8-async/issues/398>`_
+- Add :ref:`ASYNC126 <async126>` exceptiongroup-subclass-missing-derive. `(issue #334) <https://github.com/python-trio/flake8-async/issues/334>`_
 
 25.7.1
 ======

--- a/docs/rules.rst
+++ b/docs/rules.rst
@@ -25,6 +25,7 @@ _`ASYNC102` : await-in-finally-or-cancelled
     ``await`` inside ``finally``, :ref:`cancelled-catching <cancelled>` ``except:``, or ``__aexit__`` must have shielded :ref:`cancel scope <cancel_scope>` with timeout.
     If not, the async call will immediately raise a new cancellation, suppressing any cancellation that was caught.
     Not applicable to asyncio due to edge-based cancellation semantics it uses as opposed to level-based used by trio and anyio.
+    Calls to ``.aclose()`` (with no arguments) and to :func:`trio.aclose_forcefully` / :func:`anyio.aclose_forcefully` are exempt, as they are intended for use in cleanup.
     See :ref:`ASYNC120 <async120>` for the general case where other exceptions might get suppressed.
 
 ASYNC103 : no-reraise-cancelled

--- a/docs/rules.rst
+++ b/docs/rules.rst
@@ -123,6 +123,14 @@ _`ASYNC125`: constant-absolute-deadline
     :func:`anyio.move_on_after`, or the ``relative_deadline`` parameter to
     :class:`trio.CancelScope`.
 
+_`ASYNC126`: exceptiongroup-subclass-missing-derive
+    A subclass of :class:`ExceptionGroup` or :class:`BaseExceptionGroup` must override
+    :meth:`~BaseExceptionGroup.derive` to return an instance of itself, otherwise
+    :meth:`~BaseExceptionGroup.split` and :meth:`~BaseExceptionGroup.subgroup` - which
+    are used by e.g. :ref:`taskgroup_nursery` implementations - will silently produce
+    plain ``ExceptionGroup`` instances and lose the custom subclass.
+    See `trio#3175 <https://github.com/python-trio/trio/issues/3175>`_ for motivation.
+
 Blocking sync calls in async functions
 ======================================
 

--- a/flake8_async/visitors/visitor102_120.py
+++ b/flake8_async/visitors/visitor102_120.py
@@ -84,17 +84,22 @@ class Visitor102(Flake8AsyncVisitor):
         self._potential_120.clear()
 
     def is_safe_aclose_call(self, node: ast.Await) -> bool:
-        return (
-            isinstance(node.value, ast.Call)
-            # only known safe if no arguments
+        if not isinstance(node.value, ast.Call):
+            return False
+        # allow `<x>.aclose()` with no arguments
+        if (
+            isinstance(node.value.func, ast.Attribute)
+            and node.value.func.attr == "aclose"
             and not node.value.args
             and not node.value.keywords
-            and isinstance(node.value.func, ast.Attribute)
-            and node.value.func.attr == "aclose"
-        )
+        ):
+            return True
+        # allow `trio.aclose_forcefully(<x>)` / `anyio.aclose_forcefully(<x>)`,
+        # which are specifically designed for cleanup and cancel immediately by design
+        return get_matching_call(node.value, "aclose_forcefully") is not None
 
     def visit_Await(self, node: ast.Await):
-        # allow calls to `.aclose()`
+        # allow calls to `.aclose()` and `[trio/anyio].aclose_forcefully(...)`
         if not (self.is_safe_aclose_call(node)):
             self.async_call_checker(node)
 

--- a/flake8_async/visitors/visitors.py
+++ b/flake8_async/visitors/visitors.py
@@ -552,8 +552,7 @@ class Visitor126(Flake8AsyncVisitor):
             return unparsed.rsplit(".", 1)[-1]
 
         if not any(
-            base_name(b) in ("ExceptionGroup", "BaseExceptionGroup")
-            for b in node.bases
+            base_name(b) in ("ExceptionGroup", "BaseExceptionGroup") for b in node.bases
         ):
             return
 

--- a/flake8_async/visitors/visitors.py
+++ b/flake8_async/visitors/visitors.py
@@ -532,6 +532,41 @@ class Visitor125(Flake8AsyncVisitor):
             )
 
 
+@error_class
+class Visitor126(Flake8AsyncVisitor):
+    error_codes: Mapping[str, str] = {
+        "ASYNC126": (
+            "ExceptionGroup subclass {} should override `derive`, otherwise"
+            " `split`/`subgroup` (used by e.g. nursery/TaskGroup"
+            " implementations) will silently produce plain `ExceptionGroup`"
+            " instances instead of `{}`."
+        )
+    }
+
+    def visit_ClassDef(self, node: ast.ClassDef):
+        def base_name(base: ast.expr) -> str:
+            # strip generic subscripts like `ExceptionGroup[Foo]`
+            if isinstance(base, ast.Subscript):
+                base = base.value
+            unparsed = ast.unparse(base)
+            return unparsed.rsplit(".", 1)[-1]
+
+        if not any(
+            base_name(b) in ("ExceptionGroup", "BaseExceptionGroup")
+            for b in node.bases
+        ):
+            return
+
+        for item in node.body:
+            if (
+                isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and item.name == "derive"
+            ):
+                return
+
+        self.error(node, node.name, node.name)
+
+
 @error_class_cst
 class Visitor300(Flake8AsyncVisitor_cst):
     error_codes: Mapping[str, str] = {

--- a/tests/eval_files/async102.py
+++ b/tests/eval_files/async102.py
@@ -345,3 +345,22 @@ async def foo():
         await x.aclose(bar=foo)  # ASYNC102: 8, Statement("try/finally", lineno-9)
         await x.aclose(*foo)  # ASYNC102: 8, Statement("try/finally", lineno-10)
         await x.aclose(None)  # ASYNC102: 8, Statement("try/finally", lineno-11)
+
+
+# aclose_forcefully is designed for cleanup and is safe in finally/except
+# see https://github.com/python-trio/flake8-async/issues/446
+async def foo_aclose_forcefully():
+    x = None
+
+    try:
+        ...
+    except BaseException:
+        await trio.aclose_forcefully(x)
+    finally:
+        await trio.aclose_forcefully(x)
+
+    # unqualified or unknown-base call is still treated as unsafe
+    try:
+        ...
+    finally:
+        await aclose_forcefully(x)  # ASYNC102: 8, Statement("try/finally", lineno-3)

--- a/tests/eval_files/async126.py
+++ b/tests/eval_files/async126.py
@@ -1,0 +1,67 @@
+import sys
+
+if sys.version_info < (3, 11):
+    from exceptiongroup import BaseExceptionGroup, ExceptionGroup
+
+
+class NoDerive(ExceptionGroup):  # error: 0, "NoDerive", "NoDerive"
+    pass
+
+
+class NoDeriveBase(BaseExceptionGroup):  # error: 0, "NoDeriveBase", "NoDeriveBase"
+    pass
+
+
+class NoDeriveGeneric(ExceptionGroup[Exception]):  # error: 0, "NoDeriveGeneric", "NoDeriveGeneric"
+    pass
+
+
+import exceptiongroup
+
+
+class NoDeriveQualified(exceptiongroup.ExceptionGroup):  # error: 0, "NoDeriveQualified", "NoDeriveQualified"
+    pass
+
+
+class SomeMixin: ...
+
+
+class MultipleBases(SomeMixin, ExceptionGroup):  # error: 0, "MultipleBases", "MultipleBases"
+    pass
+
+
+# safe - overrides derive
+class HasDerive(ExceptionGroup):
+    def derive(self, excs):
+        return HasDerive(self.message, excs)
+
+
+class HasDeriveBase(BaseExceptionGroup):
+    def derive(self, excs):
+        return HasDeriveBase(self.message, excs)
+
+
+class HasDeriveGeneric(ExceptionGroup[Exception]):
+    def derive(self, excs):
+        return HasDeriveGeneric(self.message, excs)
+
+
+# async derive is weird but counts
+class AsyncDerive(ExceptionGroup):
+    async def derive(self, excs):  # type: ignore
+        return AsyncDerive(self.message, excs)
+
+
+# not an ExceptionGroup subclass
+class NotAnEG(Exception):
+    pass
+
+
+# nested class
+class Outer:
+    class InnerNoDerive(ExceptionGroup):  # error: 4, "InnerNoDerive", "InnerNoDerive"
+        pass
+
+    class InnerHasDerive(ExceptionGroup):
+        def derive(self, excs):
+            return Outer.InnerHasDerive(self.message, excs)

--- a/tests/eval_files/async126.py
+++ b/tests/eval_files/async126.py
@@ -8,31 +8,25 @@ class NoDerive(ExceptionGroup):  # error: 0, "NoDerive", "NoDerive"
     pass
 
 
-class NoDeriveBase(BaseExceptionGroup):  # error: 0, "NoDeriveBase", "NoDeriveBase"
+class NoDeriveBE(BaseExceptionGroup):  # error: 0, "NoDeriveBE", "NoDeriveBE"
     pass
 
 
-class NoDeriveGeneric(
-    ExceptionGroup[Exception]
-):  # error: 0, "NoDeriveGeneric", "NoDeriveGeneric"
+class NoDeriveG(ExceptionGroup[Exception]):  # error: 0, "NoDeriveG", "NoDeriveG"
     pass
 
 
-import exceptiongroup
+import exceptiongroup as eg
 
 
-class NoDeriveQualified(
-    exceptiongroup.ExceptionGroup
-):  # error: 0, "NoDeriveQualified", "NoDeriveQualified"
+class NoDeriveQ(eg.ExceptionGroup):  # error: 0, "NoDeriveQ", "NoDeriveQ"
     pass
 
 
-class SomeMixin: ...
+class _Mixin: ...
 
 
-class MultipleBases(
-    SomeMixin, ExceptionGroup
-):  # error: 0, "MultipleBases", "MultipleBases"
+class MultiBase(_Mixin, ExceptionGroup):  # error: 0, "MultiBase", "MultiBase"
     pass
 
 
@@ -42,20 +36,20 @@ class HasDerive(ExceptionGroup):
         return HasDerive(self.message, excs)
 
 
-class HasDeriveBase(BaseExceptionGroup):
+class HasDeriveBE(BaseExceptionGroup):
     def derive(self, excs):
-        return HasDeriveBase(self.message, excs)
+        return HasDeriveBE(self.message, excs)
 
 
-class HasDeriveGeneric(ExceptionGroup[Exception]):
+class HasDeriveG(ExceptionGroup[Exception]):
     def derive(self, excs):
-        return HasDeriveGeneric(self.message, excs)
+        return HasDeriveG(self.message, excs)
 
 
 # async derive is weird but counts
-class AsyncDerive(ExceptionGroup):
+class AsyncDer(ExceptionGroup):
     async def derive(self, excs):  # type: ignore
-        return AsyncDerive(self.message, excs)
+        return AsyncDer(self.message, excs)
 
 
 # not an ExceptionGroup subclass
@@ -65,9 +59,9 @@ class NotAnEG(Exception):
 
 # nested class
 class Outer:
-    class InnerNoDerive(ExceptionGroup):  # error: 4, "InnerNoDerive", "InnerNoDerive"
+    class InnerNo(ExceptionGroup):  # error: 4, "InnerNo", "InnerNo"
         pass
 
-    class InnerHasDerive(ExceptionGroup):
+    class InnerHas(ExceptionGroup):
         def derive(self, excs):
-            return Outer.InnerHasDerive(self.message, excs)
+            return Outer.InnerHas(self.message, excs)

--- a/tests/eval_files/async126.py
+++ b/tests/eval_files/async126.py
@@ -12,21 +12,27 @@ class NoDeriveBase(BaseExceptionGroup):  # error: 0, "NoDeriveBase", "NoDeriveBa
     pass
 
 
-class NoDeriveGeneric(ExceptionGroup[Exception]):  # error: 0, "NoDeriveGeneric", "NoDeriveGeneric"
+class NoDeriveGeneric(
+    ExceptionGroup[Exception]
+):  # error: 0, "NoDeriveGeneric", "NoDeriveGeneric"
     pass
 
 
 import exceptiongroup
 
 
-class NoDeriveQualified(exceptiongroup.ExceptionGroup):  # error: 0, "NoDeriveQualified", "NoDeriveQualified"
+class NoDeriveQualified(
+    exceptiongroup.ExceptionGroup
+):  # error: 0, "NoDeriveQualified", "NoDeriveQualified"
     pass
 
 
 class SomeMixin: ...
 
 
-class MultipleBases(SomeMixin, ExceptionGroup):  # error: 0, "MultipleBases", "MultipleBases"
+class MultipleBases(
+    SomeMixin, ExceptionGroup
+):  # error: 0, "MultipleBases", "MultipleBases"
     pass
 
 

--- a/tests/test_flake8_async.py
+++ b/tests/test_flake8_async.py
@@ -521,6 +521,7 @@ error_codes_ignored_when_checking_transformed_sync_code = {
     "ASYNC122",
     "ASYNC123",
     "ASYNC125",
+    "ASYNC126",
     "ASYNC300",
     "ASYNC400",
     "ASYNC912",


### PR DESCRIPTION
Warn when a class inherits from `ExceptionGroup` / `BaseExceptionGroup` but doesn't override `derive`. Without that override, `split`/`subgroup` (as used by nursery and TaskGroup implementations) silently produce plain `ExceptionGroup` instances instead of the custom subclass.  Fixes #334.

Also fixes https://github.com/python-trio/flake8-async/issues/446.