### PR TITLE
Support and encourage use of `httpx2`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,11 @@ Changelog
 
 `CalVer, YY.month.patch <https://calver.org/>`_
 
+26.6.1
+======
+- Add :ref:`ASYNC127 <async127>` unmaintained-httpx: use ``httpx2`` instead of ``httpx``, which is no longer maintained, to get security updates. `(issue #460) <https://github.com/python-trio/flake8-async/issues/460>`_
+- :ref:`ASYNC210 <async210>`, :ref:`ASYNC211 <async211>` and :ref:`ASYNC212 <async212>` now also detect blocking calls made through ``httpx2``, and their messages recommend ``httpx2.AsyncClient`` instead of ``httpx.AsyncClient``.
+
 26.4.2
 ======
 - Fixed a regression in canonical-qualname resolution where a call nested inside an attribute chain (e.g. ``foo("x").bar``) was silently elided into a dotted name (``"foo.bar"``). This caused :ref:`ASYNC200 <async200>` false alarms for patterns like ``*session.get`` matching ``read_session("a").get(...)``, where ``.get`` is a method on the *return value* of ``read_session()``.

--- a/docs/rules.rst
+++ b/docs/rules.rst
@@ -134,6 +134,13 @@ _`ASYNC126`: exceptiongroup-subclass-missing-derive
     plain ``ExceptionGroup`` instances and lose the custom subclass.
     See `trio#3175 <https://github.com/python-trio/trio/issues/3175>`_ for motivation.
 
+_`ASYNC127`: unmaintained-httpx
+    The original ``httpx`` package is no longer maintained, which is a problem for a
+    networking library.  Use `httpx2`_ - the continuation of the project, maintained
+    by Pydantic - to keep getting security updates.  It uses the same API, so
+    migration is usually just a matter of replacing ``httpx`` with ``httpx2`` in
+    imports.  This rule triggers on any import of ``httpx``.
+
 Blocking sync calls in async functions
 ======================================
 
@@ -141,8 +148,10 @@ Our 2xx lint rules warn you to use the async equivalent for slow sync calls whic
 would otherwise block the event loop (and therefore cause performance problems,
 or even deadlock).
 
+.. _httpx2: https://httpx2.pydantic.dev/
 .. _httpx.Client: https://www.python-httpx.org/api/#client
-.. _httpx.AsyncClient: https://www.python-httpx.org/api/#asyncclient
+.. _httpx2.Client: https://httpx2.pydantic.dev/api/#client
+.. _httpx2.AsyncClient: https://httpx2.pydantic.dev/api/#asyncclient
 .. _urllib3: https://github.com/urllib3/urllib3
 .. _aiofiles: https://pypi.org/project/aiofiles/
 .. _anyio: https://github.com/agronholm/anyio
@@ -151,16 +160,17 @@ _`ASYNC200` : blocking-configured-call
     User-configured error for blocking sync calls in async functions.
     Does nothing by default, see :ref:`async200-blocking-calls` for how to configure it.
 
-ASYNC210 : blocking-http-call
-    Sync HTTP call in async function, use `httpx.AsyncClient`_.
-    This and the other :ref:`ASYNC21x <ASYNC211>` checks look for usage of `urllib3`_ and `httpx.Client`_, and recommend using `httpx.AsyncClient`_ as that's the largest http client supporting anyio/trio.
+_`ASYNC210` : blocking-http-call
+    Sync HTTP call in async function, use `httpx2.AsyncClient`_.
+    This and the other :ref:`ASYNC21x <ASYNC211>` checks look for usage of `urllib3`_, `httpx.Client`_, and `httpx2.Client`_, and recommend using `httpx2.AsyncClient`_ as that's the largest http client supporting anyio/trio.
+    Sync calls through the unmaintained ``httpx`` package are detected the same way as ``httpx2`` ones, but the recommendation is always `httpx2.AsyncClient`_ - see :ref:`ASYNC127 <ASYNC127>`.
 
 _`ASYNC211` : blocking-http-call-pool
-    Likely sync HTTP call in async function, use `httpx.AsyncClient`_.
+    Likely sync HTTP call in async function, use `httpx2.AsyncClient`_.
     Looks for `urllib3`_ method calls on pool objects, but only matching on the method signature and not the object.
 
-ASYNC212 : blocking-http-call-httpx
-    Blocking sync HTTP call on httpx object, use `httpx.AsyncClient`_.
+_`ASYNC212` : blocking-http-call-httpx
+    Blocking sync HTTP call on httpx/httpx2 object, use `httpx2.AsyncClient`_.
 
 ASYNC220 : blocking-create-subprocess
     Sync call to :class:`subprocess.Popen` (or equivalent) in async function, use :func:`trio.run_process`/:func:`anyio.run_process`/:ref:`asyncio.create_subprocess_[exec/shell] <asyncio-subprocess>` in a :ref:`taskgroup_nursery`.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -33,7 +33,7 @@ adding the following to your ``.pre-commit-config.yaml``:
    minimum_pre_commit_version: '2.9.0'
    repos:
    - repo: https://github.com/python-trio/flake8-async
-     rev: 26.4.2
+     rev: 26.6.1
      hooks:
        - id: flake8-async
          # args: ["--enable=ASYNC100,ASYNC112", "--disable=", "--autofix=ASYNC"]

--- a/flake8_async/__init__.py
+++ b/flake8_async/__init__.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 
 
 # CalVer: YY.month.patch, e.g. first release of July 2022 == "22.7.1"
-__version__ = "26.4.2"
+__version__ = "26.6.1"
 
 
 # taken from https://github.com/Zac-HD/shed

--- a/flake8_async/visitors/visitor2xx.py
+++ b/flake8_async/visitors/visitor2xx.py
@@ -62,9 +62,9 @@ class Visitor200(Flake8AsyncVisitor):
 @error_class
 class Visitor21X(Visitor200):
     error_codes: Mapping[str, str] = {
-        "ASYNC210": "Sync HTTP call {} in async function, use `httpx.AsyncClient`.",
+        "ASYNC210": "Sync HTTP call {} in async function, use `httpx2.AsyncClient`.",
         "ASYNC211": (
-            "Likely sync HTTP call {} in async function, use `httpx.AsyncClient`."
+            "Likely sync HTTP call {} in async function, use `httpx2.AsyncClient`."
         ),
     }
 
@@ -77,17 +77,12 @@ class Visitor21X(Visitor200):
         http_methods = {"get", "options", "head", "post", "put", "patch", "delete"}
         func_name = ast.unparse(node.func)
         canonical = self.canonical_name(node.func) or func_name
-        for http_package in "requests", "httpx":
-            if get_matching_call(
-                node,
-                *http_methods | {"request"},
-                base=http_package,
-                imports=self.imports,
-            ):
-                self.error(node, func_name, error_code="ASYNC210")
-                return
-
-        if canonical in (
+        if get_matching_call(
+            node,
+            *http_methods | {"request"},
+            base=("requests", "httpx", "httpx2"),
+            imports=self.imports,
+        ) or canonical in (
             "urllib3.request",
             "urllib.request.urlopen",
             "request.urlopen",
@@ -107,53 +102,61 @@ class Visitor21X(Visitor200):
             self.error(node, func_name, error_code="ASYNC211")
 
 
+httpx_blocking_methods = (
+    "close",
+    "delete",
+    "get",
+    "head",
+    "options",
+    "patch",
+    "post",
+    "put",
+    "request",
+    "send",
+    "stream",
+)
+
+
 @error_class
 class Visitor212(Visitor200):
     error_codes: Mapping[str, str] = {
         "ASYNC212": (
-            "Blocking sync HTTP call {0} on httpx object {1}, use httpx.AsyncClient."
+            "Blocking sync HTTP call {0} on httpx/httpx2 object {1},"
+            " use httpx2.AsyncClient."
         )
     }
 
     def __init__(self, *args: Any, **kwargs: Any):
-        self.dangerous_classes = (
-            "httpx.Client",
-            "urllib3.HTTPConnectionPool",
-            "urllib3.HTTPSConnectionPool",
-            "urllib3.PoolManager",
-            "urllib3.ProxyManager",
-            "urllib3.connectionpool.ConnectionPool",
-            "urllib3.connectionpool.HTTPConnectionPool",
-            "urllib3.connectionpool.HTTPSConnectionPool",
-            "urllib3.poolmanager.PoolManager",
-            "urllib3.poolmanager.ProxyManager",
-            "urllib3.request.RequestMethods",
-        )
+        # class -> methods that block. None means all methods block.
+        self.dangerous_classes: dict[str, tuple[str, ...] | None] = {
+            "httpx.Client": httpx_blocking_methods,
+            "httpx2.Client": httpx_blocking_methods,
+            "urllib3.HTTPConnectionPool": None,
+            "urllib3.HTTPSConnectionPool": None,
+            "urllib3.PoolManager": None,
+            "urllib3.ProxyManager": None,
+            "urllib3.connectionpool.ConnectionPool": None,
+            "urllib3.connectionpool.HTTPConnectionPool": None,
+            "urllib3.connectionpool.HTTPSConnectionPool": None,
+            "urllib3.poolmanager.PoolManager": None,
+            "urllib3.poolmanager.ProxyManager": None,
+            "urllib3.request.RequestMethods": None,
+        }
         super().__init__(*args, **kwargs)
         for c in self.dangerous_classes:
             self.typed_calls[c] = c
 
     def visit_blocking_call(self, node: ast.Call):
-        httpx_blocking_methods = (
-            "close",
-            "delete",
-            "get",
-            "head",
-            "options",
-            "patch",
-            "post",
-            "put",
-            "request",
-            "send",
-            "stream",
-        )
         if (
             isinstance(node.func, ast.Attribute)
             and isinstance(node.func.value, ast.Name)
             and node.func.value.id in self.variables
             and (anno := self.variables.get(node.func.value.id))
-            and (anno != "httpx.Client" or node.func.attr in httpx_blocking_methods)
             and anno in self.dangerous_classes
+            and (
+                (blocking_methods := self.dangerous_classes[anno]) is None
+                or node.func.attr in blocking_methods
+            )
         ):
             self.error(node, node.func.attr, node.func.value.id)
 

--- a/flake8_async/visitors/visitors.py
+++ b/flake8_async/visitors/visitors.py
@@ -593,6 +593,30 @@ class Visitor126(Flake8AsyncVisitor):
         self.error(node, node.name, node.name)
 
 
+@error_class
+class Visitor127(Flake8AsyncVisitor):
+    error_codes: Mapping[str, str] = {
+        "ASYNC127": (
+            "Use `httpx2` instead of `httpx`, which is no longer maintained,"
+            " to get security updates."
+        ),
+    }
+
+    @staticmethod
+    def _is_httpx(module: str) -> bool:
+        return module == "httpx" or module.startswith("httpx.")
+
+    def visit_Import(self, node: ast.Import):
+        if any(self._is_httpx(name.name) for name in node.names):
+            self.error(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom):
+        # relative imports (level != 0) refer to local modules, not the httpx package,
+        # and `from . import x` has no module name at all
+        if node.level == 0 and self._is_httpx(node.module or ""):
+            self.error(node)
+
+
 @error_class_cst
 class Visitor300(Flake8AsyncVisitor_cst):
     error_codes: Mapping[str, str] = {

--- a/tests/eval_files/async127.py
+++ b/tests/eval_files/async127.py
@@ -1,0 +1,30 @@
+# type: ignore
+# isort: skip
+import importlib
+
+import httpx  # error: 0
+import httpx as foo  # error: 0
+import httpx.config  # error: 0
+import httpx, httpx.config  # error: 0
+from httpx import AsyncClient  # error: 0
+from httpx import Client as bar  # error: 0
+from httpx import *  # error: 0
+from httpx._client import Client  # error: 0
+
+# httpx2 is the maintained continuation of httpx, and is what we recommend
+import httpx2
+import httpx2 as foo2
+from httpx2 import AsyncClient
+
+# other modules that happen to share a prefix or name are fine
+import httpx_auth
+from httpx_auth import Whatever
+import foo.httpx
+from foo.httpx import bar
+
+# relative imports refer to local modules, not the httpx package
+from . import httpx
+from .httpx import Client
+
+# ways of sidestepping the check, that we don't attempt to detect
+k = importlib.import_module("httpx")

--- a/tests/eval_files/async210.py
+++ b/tests/eval_files/async210.py
@@ -2,6 +2,7 @@
 import urllib
 
 import httpx
+import httpx2
 import requests
 import urllib3
 
@@ -30,6 +31,16 @@ async def foo():
     httpx.patch("")  # ASYNC210: 4, 'httpx.patch'
     httpx.delete("")  # ASYNC210: 4, 'httpx.delete'
     httpx.foo()
+
+    httpx2.get("")  # ASYNC210: 4, 'httpx2.get'
+    httpx2.options("")  # ASYNC210: 4, 'httpx2.options'
+    httpx2.head("")  # ASYNC210: 4, 'httpx2.head'
+    httpx2.post("")  # ASYNC210: 4, 'httpx2.post'
+    httpx2.put("")  # ASYNC210: 4, 'httpx2.put'
+    httpx2.patch("")  # ASYNC210: 4, 'httpx2.patch'
+    httpx2.delete("")  # ASYNC210: 4, 'httpx2.delete'
+    httpx2.request("GET", "")  # ASYNC210: 4, 'httpx2.request'
+    httpx2.foo()
 
     urllib3.request()  # ASYNC210: 4, 'urllib3.request'
     urllib3.request(...)  # ASYNC210: 4, 'urllib3.request'

--- a/tests/eval_files/async212.py
+++ b/tests/eval_files/async212.py
@@ -60,6 +60,35 @@ async def foo_global_client_overriden():
     glob_client.send()
 
 
+# httpx2 (the maintained continuation of httpx) is treated identically
+async def foo_httpx2_call():
+    client = httpx2.Client()
+    client.close()  # ASYNC212: 4, "close", "client"
+    client.delete()  # ASYNC212: 4, "delete", "client"
+    client.get()  # ASYNC212: 4, "get", "client"
+    client.head()  # ASYNC212: 4, "head", "client"
+    client.options()  # ASYNC212: 4, "options", "client"
+    client.patch()  # ASYNC212: 4, "patch", "client"
+    client.post()  # ASYNC212: 4, "post", "client"
+    client.put()  # ASYNC212: 4, "put", "client"
+    client.request()  # ASYNC212: 4, "request", "client"
+    client.send()  # ASYNC212: 4, "send", "client"
+    client.stream()  # ASYNC212: 4, "stream", "client"
+
+    client.anything()
+    client.build_request()
+    client.is_closed
+
+
+async def foo_httpx2_ann_par(client: httpx2.Client):
+    client.send(...)  # ASYNC212: 4, "send", "client"
+
+
+async def foo_httpx2_ann_var():
+    client: httpx2.Client = ...
+    client.send()  # ASYNC212: 4, "send", "client"
+
+
 # not implemented
 from httpx import Client
 

--- a/tests/test_flake8_async.py
+++ b/tests/test_flake8_async.py
@@ -540,6 +540,7 @@ error_codes_ignored_when_checking_transformed_sync_code = {
     "ASYNC123",
     "ASYNC125",
     "ASYNC126",
+    "ASYNC127",
     "ASYNC300",
     "ASYNC400",
     "ASYNC912",


### PR DESCRIPTION
The original `httpx` package is no longer maintained; `httpx2` is the continuation of the project, maintained by Pydantic.

- Add ASYNC127 unmaintained-httpx: triggers on any import of `httpx`, recommending `httpx2` to keep getting security updates.
- ASYNC210 and ASYNC212 now detect blocking calls made through `httpx2` identically to `httpx` ones.
- ASYNC210/211/212 messages now recommend `httpx2.AsyncClient` instead of `httpx.AsyncClient`.

Closes #460.